### PR TITLE
Epic 2 - JavaFX 25 CodeArea Integration (Task 2.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <version>0.1.0</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -59,7 +59,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <release>21</release>
+                    <release>25</release>
                     <compilerArgs>
                         <arg>--enable-preview</arg>
                         <arg>--add-modules</arg>

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -1,13 +1,13 @@
 package org.geantlr.views;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.TextArea;
+import jfx.incubator.scene.control.richtext.CodeArea;
 import org.geantlr.viewmodels.EditorViewModel;
 
 public class EditorViewController {
 
     @FXML
-    private TextArea editorTextArea;
+    private CodeArea editorCodeArea;
 
     private EditorViewModel viewModel;
 
@@ -15,9 +15,21 @@ public class EditorViewController {
     public void initialize() {
         viewModel = new EditorViewModel();
 
-        // Bind the text area text property to the view model's text content property bidirectionally
-        if (editorTextArea != null) {
-            editorTextArea.textProperty().bindBidirectional(viewModel.textContentProperty());
+        // Update view model when CodeArea text changes
+        if (editorCodeArea != null) {
+            editorCodeArea.getModel().addListener(change -> {
+                viewModel.setTextContent(editorCodeArea.getText());
+            });
+
+            // Set initial text
+            editorCodeArea.setText(viewModel.getTextContent());
+
+            // Listen to view model changes
+            viewModel.textContentProperty().addListener((obs, oldVal, newVal) -> {
+                if (!newVal.equals(editorCodeArea.getText())) {
+                    editorCodeArea.setText(newVal);
+                }
+            });
         }
     }
 

--- a/src/main/resources/org/geantlr/views/EditorView.fxml
+++ b/src/main/resources/org/geantlr/views/EditorView.fxml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.TextArea?>
+<?import jfx.incubator.scene.control.richtext.CodeArea?>
 <?import javafx.scene.layout.StackPane?>
 
 <StackPane xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1"
            fx:controller="org.geantlr.views.EditorViewController"
            style="-fx-border-color: gray; -fx-background-color: -color-bg-default;">
 
-    <TextArea fx:id="editorTextArea" promptText="Enter text here..." wrapText="true"/>
+    <CodeArea fx:id="editorCodeArea" wrapText="true"/>
 
 </StackPane>


### PR DESCRIPTION
This commit implements Task 2.2 from Epic 2, integrating the experimental JavaFX 25 CodeArea into the application's editor view. The Maven build file was updated to compile against Java 25 to support the incubator rich text components. The FXML layout and the controller were updated to instantiate CodeArea and properly sync its underlying text model with the application's view model.

---
*PR created automatically by Jules for task [12861203941255828191](https://jules.google.com/task/12861203941255828191) started by @tkpixel*