### PR TITLE
Feature: Client-Side Window Decorations (Task 2.3)

### DIFF
--- a/src/main/java/org/geantlr/App.java
+++ b/src/main/java/org/geantlr/App.java
@@ -4,9 +4,11 @@ import atlantafx.base.theme.PrimerDark;
 import atlantafx.base.theme.PrimerLight;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
+import javafx.scene.Cursor;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 import java.io.IOException;
 
 public class App extends Application {
@@ -28,8 +30,93 @@ public class App extends Application {
         scene.getStylesheets().add(customCss);
 
         stage.setTitle("GeantLR Editor Demo");
+        stage.initStyle(StageStyle.UNDECORATED);
         stage.setScene(scene);
+
+        addResizeListener(stage, scene);
+
         stage.show();
+    }
+
+    private void addResizeListener(Stage stage, Scene scene) {
+        final int RESIZE_MARGIN = 5;
+
+        scene.setOnMouseMoved(event -> {
+            double x = event.getSceneX();
+            double y = event.getSceneY();
+            double width = scene.getWidth();
+            double height = scene.getHeight();
+
+            if (x < RESIZE_MARGIN && y < RESIZE_MARGIN) {
+                scene.setCursor(Cursor.NW_RESIZE);
+            } else if (x > width - RESIZE_MARGIN && y < RESIZE_MARGIN) {
+                scene.setCursor(Cursor.NE_RESIZE);
+            } else if (x < RESIZE_MARGIN && y > height - RESIZE_MARGIN) {
+                scene.setCursor(Cursor.SW_RESIZE);
+            } else if (x > width - RESIZE_MARGIN && y > height - RESIZE_MARGIN) {
+                scene.setCursor(Cursor.SE_RESIZE);
+            } else if (x < RESIZE_MARGIN) {
+                scene.setCursor(Cursor.W_RESIZE);
+            } else if (x > width - RESIZE_MARGIN) {
+                scene.setCursor(Cursor.E_RESIZE);
+            } else if (y < RESIZE_MARGIN) {
+                scene.setCursor(Cursor.N_RESIZE);
+            } else if (y > height - RESIZE_MARGIN) {
+                scene.setCursor(Cursor.S_RESIZE);
+            } else {
+                scene.setCursor(Cursor.DEFAULT);
+            }
+        });
+
+        // The following logic uses wrapper arrays because variables used in lambdas must be final
+        final double[] startX = new double[1];
+        final double[] startY = new double[1];
+        final double[] startWidth = new double[1];
+        final double[] startHeight = new double[1];
+        final double[] stageX = new double[1];
+        final double[] stageY = new double[1];
+
+        scene.setOnMousePressed(event -> {
+            startX[0] = event.getScreenX();
+            startY[0] = event.getScreenY();
+            startWidth[0] = stage.getWidth();
+            startHeight[0] = stage.getHeight();
+            stageX[0] = stage.getX();
+            stageY[0] = stage.getY();
+        });
+
+        scene.setOnMouseDragged(event -> {
+            Cursor cursor = scene.getCursor();
+            if (cursor == Cursor.DEFAULT) {
+                return;
+            }
+
+            double deltaX = event.getScreenX() - startX[0];
+            double deltaY = event.getScreenY() - startY[0];
+            double minWidth = 400; // minimum width
+            double minHeight = 300; // minimum height
+
+            if (cursor == Cursor.E_RESIZE || cursor == Cursor.NE_RESIZE || cursor == Cursor.SE_RESIZE) {
+                stage.setWidth(Math.max(minWidth, startWidth[0] + deltaX));
+            }
+            if (cursor == Cursor.S_RESIZE || cursor == Cursor.SW_RESIZE || cursor == Cursor.SE_RESIZE) {
+                stage.setHeight(Math.max(minHeight, startHeight[0] + deltaY));
+            }
+            if (cursor == Cursor.W_RESIZE || cursor == Cursor.NW_RESIZE || cursor == Cursor.SW_RESIZE) {
+                double newWidth = startWidth[0] - deltaX;
+                if (newWidth > minWidth) {
+                    stage.setX(stageX[0] + deltaX);
+                    stage.setWidth(newWidth);
+                }
+            }
+            if (cursor == Cursor.N_RESIZE || cursor == Cursor.NW_RESIZE || cursor == Cursor.NE_RESIZE) {
+                double newHeight = startHeight[0] - deltaY;
+                if (newHeight > minHeight) {
+                    stage.setY(stageY[0] + deltaY);
+                    stage.setHeight(newHeight);
+                }
+            }
+        });
     }
 
     public static void main(String[] args) {

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -5,16 +5,36 @@ import atlantafx.base.theme.PrimerLight;
 import javafx.application.Application;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.application.Platform;
 import javafx.scene.control.SplitPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.control.Label;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.stage.Stage;
 import javafx.fxml.FXMLLoader;
 import java.io.IOException;
 import org.geantlr.viewmodels.MainViewModel;
 import org.kordamp.ikonli.javafx.FontIcon;
 
 public class MainViewController {
+
+    @FXML
+    private HBox titleBar;
+
+    @FXML
+    private Button minimizeBtn;
+
+    @FXML
+    private Button maximizeBtn;
+
+    @FXML
+    private FontIcon maximizeIcon;
+
+    @FXML
+    private Button closeBtn;
 
     @FXML
     private SplitPane editorSplitPane;
@@ -32,12 +52,17 @@ public class MainViewController {
     private Region primaryEditor;
     private Region secondaryEditor;
 
+    private double xOffset = 0;
+    private double yOffset = 0;
+
     @FXML
     public void initialize() {
         viewModel = new MainViewModel();
 
         // Use an accent button style if provided by AtlantaFX
         themeToggleBtn.getStyleClass().addAll("accent");
+
+        setupTitleBar();
 
         // Create editors from FXML
         primaryEditor = loadEditorView();
@@ -65,6 +90,62 @@ public class MainViewController {
             Application.setUserAgentStylesheet(new PrimerLight().getUserAgentStylesheet());
             themeIcon.setIconLiteral("mdi2m-moon-waning-crescent");
         }
+    }
+
+    private void setupTitleBar() {
+        titleBar.setOnMousePressed(event -> {
+            if (event.getButton() == MouseButton.PRIMARY) {
+                // Ignore top 5 pixels to allow vertical resizing without moving the window
+                if (event.getY() > 5) {
+                    xOffset = event.getSceneX();
+                    yOffset = event.getSceneY();
+                } else {
+                    xOffset = -1; // Indicate invalid drag start
+                    yOffset = -1;
+                }
+            }
+        });
+
+        titleBar.setOnMouseDragged(event -> {
+            if (event.getButton() == MouseButton.PRIMARY && yOffset > 5) {
+                Stage stage = (Stage) titleBar.getScene().getWindow();
+                // Prevent dragging if maximized
+                if (!stage.isMaximized()) {
+                    stage.setX(event.getScreenX() - xOffset);
+                    stage.setY(event.getScreenY() - yOffset);
+                }
+            }
+        });
+
+        titleBar.setOnMouseClicked(event -> {
+            if (event.getButton() == MouseButton.PRIMARY && event.getClickCount() == 2) {
+                maximizeWindow();
+            }
+        });
+    }
+
+    @FXML
+    private void minimizeWindow() {
+        Stage stage = (Stage) titleBar.getScene().getWindow();
+        stage.setIconified(true);
+    }
+
+    @FXML
+    private void maximizeWindow() {
+        Stage stage = (Stage) titleBar.getScene().getWindow();
+        if (stage.isMaximized()) {
+            stage.setMaximized(false);
+            maximizeIcon.setIconLiteral("mdi2w-window-maximize");
+        } else {
+            stage.setMaximized(true);
+            maximizeIcon.setIconLiteral("mdi2w-window-restore");
+        }
+    }
+
+    @FXML
+    private void closeWindow() {
+        Stage stage = (Stage) titleBar.getScene().getWindow();
+        stage.fireEvent(new javafx.stage.WindowEvent(stage, javafx.stage.WindowEvent.WINDOW_CLOSE_REQUEST));
     }
 
     @FXML

--- a/src/main/resources/org/geantlr/theme.css
+++ b/src/main/resources/org/geantlr/theme.css
@@ -6,4 +6,49 @@
     /* Set the requested secondary color */
     -color-accent-emphasis: #5747a6;
     -color-accent-fg: #5747a6;
+
+    /* Undecorated window styling */
+    -fx-border-color: -color-border-default;
+    -fx-border-width: 1px;
+}
+
+/* Custom Title Bar Styling */
+.title-bar {
+    -fx-background-color: -color-bg-subtle;
+    -fx-padding: 8px 10px;
+    -fx-border-color: -color-border-muted;
+    -fx-border-width: 0 0 1px 0;
+}
+
+.title-label {
+    -fx-font-weight: bold;
+    -fx-text-fill: -color-fg-default;
+}
+
+.window-btn {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+    -fx-padding: 5px;
+    -fx-cursor: hand;
+}
+
+.window-btn > .ikonli-font-icon {
+    -fx-fill: -color-fg-muted;
+}
+
+.window-btn:hover {
+    -fx-background-color: -color-bg-overlay;
+    -fx-background-radius: 4px;
+}
+
+.window-btn:hover > .ikonli-font-icon {
+    -fx-fill: -color-fg-default;
+}
+
+.close-btn:hover {
+    -fx-background-color: #e81123; /* Windows close red */
+}
+
+.close-btn:hover > .ikonli-font-icon {
+    -fx-fill: white;
 }

--- a/src/main/resources/org/geantlr/views/MainView.fxml
+++ b/src/main/resources/org/geantlr/views/MainView.fxml
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.ToolBar?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 <?import org.kordamp.ikonli.javafx.FontIcon?>
 
 <VBox xmlns="http://javafx.com/javafx/25" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="org.geantlr.views.MainViewController"
       styleClass="background">
+
+    <!-- Custom Title Bar -->
+    <HBox fx:id="titleBar" styleClass="title-bar" alignment="CENTER_LEFT" spacing="10">
+        <Label text="GeantLR Editor Demo" styleClass="title-label" />
+        <Region HBox.hgrow="ALWAYS" />
+        <Button fx:id="minimizeBtn" styleClass="window-btn, minimize-btn" onAction="#minimizeWindow">
+            <graphic>
+                <FontIcon iconLiteral="mdi2w-window-minimize" iconSize="16"/>
+            </graphic>
+        </Button>
+        <Button fx:id="maximizeBtn" styleClass="window-btn, maximize-btn" onAction="#maximizeWindow">
+            <graphic>
+                <FontIcon fx:id="maximizeIcon" iconLiteral="mdi2w-window-maximize" iconSize="16"/>
+            </graphic>
+        </Button>
+        <Button fx:id="closeBtn" styleClass="window-btn, close-btn" onAction="#closeWindow">
+            <graphic>
+                <FontIcon iconLiteral="mdi2w-window-close" iconSize="16"/>
+            </graphic>
+        </Button>
+    </HBox>
 
     <ToolBar>
         <Button fx:id="themeToggleBtn" text="Toggle Theme" onAction="#toggleTheme">


### PR DESCRIPTION
Implement [Epic 2] Client-Side Window Decorations (Task 2.3).
    
This PR introduces a custom, client-side title bar for the application by removing the native OS decorations.
- `App.java`: Initializes the stage as `UNDECORATED` and introduces custom mouse listeners to detect edges and enable window resizing.
- `MainView.fxml`: Replaces the empty top area with a custom `HBox` title bar containing a title label and minimize, maximize, and close buttons utilizing Ikonli icons.
- `MainViewController.java`: Adds logic to the custom title bar to handle dragging the window (while ignoring the top 5px to allow resizing), and logic to minimize, maximize/restore, and properly close the window via a `WINDOW_CLOSE_REQUEST` event.
- `theme.css`: Uses AtlantaFX variables to style the title bar and window borders so that they seamlessly blend in both dark and light modes.

---
*PR created automatically by Jules for task [1298272323569860608](https://jules.google.com/task/1298272323569860608) started by @tkpixel*