### PR TITLE
Add GrammarLoaderService for .g4 files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <version>12.4.0</version>
         </dependency>
         <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4</artifactId>
+            <version>4.13.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>5.10.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>ikonli-materialdesign2-pack</artifactId>
             <version>12.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -12,4 +12,5 @@ module org.geantlr {
     opens org.geantlr.views to javafx.fxml;
     exports org.geantlr;
     exports org.geantlr.views;
+    exports org.geantlr.services;
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -7,6 +7,8 @@ module org.geantlr {
     requires org.kordamp.ikonli.core;
     requires org.kordamp.ikonli.javafx;
     requires org.kordamp.ikonli.materialdesign2;
+    requires org.antlr.antlr4.runtime;
+    requires antlr4;
 
     opens org.geantlr to javafx.fxml;
     opens org.geantlr.views to javafx.fxml;

--- a/src/main/java/org/geantlr/services/DynamicGrammar.java
+++ b/src/main/java/org/geantlr/services/DynamicGrammar.java
@@ -1,0 +1,50 @@
+package org.geantlr.services;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.LexerInterpreter;
+import org.antlr.v4.runtime.ParserInterpreter;
+import org.antlr.v4.runtime.TokenStream;
+import org.antlr.v4.tool.Grammar;
+import org.antlr.v4.tool.LexerGrammar;
+
+/**
+ * Encapsulates the runtime interpreter models of an ANTLR 4 grammar loaded dynamically.
+ */
+public class DynamicGrammar {
+
+    private final Grammar parserGrammar;
+    private final LexerGrammar lexerGrammar;
+
+    public DynamicGrammar(Grammar parserGrammar, LexerGrammar lexerGrammar) {
+        this.parserGrammar = parserGrammar;
+        this.lexerGrammar = lexerGrammar;
+    }
+
+    /**
+     * Creates a new instance of a LexerInterpreter based on the implicitly generated Lexer grammar.
+     *
+     * @param input The character stream to tokenize.
+     * @return A LexerInterpreter configured for this grammar.
+     */
+    public LexerInterpreter createLexerInterpreter(CharStream input) {
+        return lexerGrammar.createLexerInterpreter(input);
+    }
+
+    /**
+     * Creates a new instance of a ParserInterpreter based on the loaded parser grammar.
+     *
+     * @param input The token stream to parse.
+     * @return A ParserInterpreter configured for this grammar.
+     */
+    public ParserInterpreter createParserInterpreter(TokenStream input) {
+        return parserGrammar.createParserInterpreter(input);
+    }
+
+    public Grammar getParserGrammar() {
+        return parserGrammar;
+    }
+
+    public LexerGrammar getLexerGrammar() {
+        return lexerGrammar;
+    }
+}

--- a/src/main/java/org/geantlr/services/GrammarLoaderService.java
+++ b/src/main/java/org/geantlr/services/GrammarLoaderService.java
@@ -1,0 +1,41 @@
+package org.geantlr.services;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of IGrammarLoaderService for finding and loading .g4 files.
+ */
+public class GrammarLoaderService implements IGrammarLoaderService {
+
+    @Override
+    public List<Path> findGrammarFiles(File directory) {
+        if (directory == null || !directory.exists() || !directory.isDirectory()) {
+            return Collections.emptyList();
+        }
+
+        try (Stream<Path> paths = Files.walk(directory.toPath())) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".g4"))
+                    .collect(Collectors.toList());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public String loadGrammarContent(File grammarFile) throws IOException {
+        if (grammarFile == null || !grammarFile.exists() || !grammarFile.isFile()) {
+            throw new IllegalArgumentException("Invalid grammar file provided.");
+        }
+        return Files.readString(grammarFile.toPath());
+    }
+}

--- a/src/main/java/org/geantlr/services/GrammarLoaderService.java
+++ b/src/main/java/org/geantlr/services/GrammarLoaderService.java
@@ -1,5 +1,9 @@
 package org.geantlr.services;
 
+import org.antlr.v4.Tool;
+import org.antlr.v4.tool.Grammar;
+import org.antlr.v4.tool.LexerGrammar;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -37,5 +41,43 @@ public class GrammarLoaderService implements IGrammarLoaderService {
             throw new IllegalArgumentException("Invalid grammar file provided.");
         }
         return Files.readString(grammarFile.toPath());
+    }
+
+    @Override
+    public DynamicGrammar loadDynamicGrammar(File grammarFile) throws Exception {
+        if (grammarFile == null || !grammarFile.exists() || !grammarFile.isFile()) {
+            throw new IllegalArgumentException("Invalid grammar file provided.");
+        }
+
+        // Initialize ANTLR Tool
+        Tool tool = new Tool();
+
+        // Ensure the directory of the file is in the library path so it can resolve imports if needed
+        tool.libDirectory = grammarFile.getParentFile().getAbsolutePath();
+
+        // 2. Instantiate Grammar object.
+        // It reads and parses the .g4 file to construct AST and rules.
+        Grammar parserGrammar = tool.loadGrammar(grammarFile.getAbsolutePath());
+
+        // We only support valid combined or parser grammars for this primary entry point
+        if (parserGrammar == null) {
+            throw new IllegalStateException("Failed to load parser grammar from " + grammarFile.getName());
+        }
+
+        // 3. Extract the implicit Lexer grammar
+        LexerGrammar lexerGrammar = null;
+        if (parserGrammar.isCombined()) {
+            lexerGrammar = parserGrammar.implicitLexer;
+            if (lexerGrammar == null) {
+                throw new IllegalStateException("Combined grammar loaded, but implicit lexer is null.");
+            }
+        } else if (parserGrammar instanceof LexerGrammar) {
+            lexerGrammar = (LexerGrammar) parserGrammar;
+            parserGrammar = null; // No parser grammar
+        }
+
+        // Processing ATN is handled internally by ANTLR Tool when you ask for createLexerInterpreter or createParserInterpreter
+        // as well as vocabulary and ruleNames properties.
+        return new DynamicGrammar(parserGrammar, lexerGrammar);
     }
 }

--- a/src/main/java/org/geantlr/services/IGrammarLoaderService.java
+++ b/src/main/java/org/geantlr/services/IGrammarLoaderService.java
@@ -26,4 +26,13 @@ public interface IGrammarLoaderService {
      * @throws IOException If an error occurs reading the file.
      */
     String loadGrammarContent(File grammarFile) throws IOException;
+
+    /**
+     * Loads and compiles a grammar file into a dynamic grammar model capable of parsing text.
+     *
+     * @param grammarFile The grammar file to parse.
+     * @return A DynamicGrammar instance representing the parsed grammar and its internal ATN models.
+     * @throws Exception If compilation fails or the grammar is invalid.
+     */
+    DynamicGrammar loadDynamicGrammar(File grammarFile) throws Exception;
 }

--- a/src/main/java/org/geantlr/services/IGrammarLoaderService.java
+++ b/src/main/java/org/geantlr/services/IGrammarLoaderService.java
@@ -1,0 +1,29 @@
+package org.geantlr.services;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Service contract for dynamically loading and discovering ANTLR grammar (.g4) files.
+ */
+public interface IGrammarLoaderService {
+
+    /**
+     * Finds all grammar files (.g4) in a specific directory.
+     *
+     * @param directory The directory to search in.
+     * @return A list of paths to grammar files found in the directory.
+     */
+    List<Path> findGrammarFiles(File directory);
+
+    /**
+     * Reads the content of a grammar file.
+     *
+     * @param grammarFile The grammar file to read.
+     * @return The text content of the grammar file.
+     * @throws IOException If an error occurs reading the file.
+     */
+    String loadGrammarContent(File grammarFile) throws IOException;
+}

--- a/src/main/java/org/geantlr/viewmodels/MainViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/MainViewModel.java
@@ -3,10 +3,17 @@ package org.geantlr.viewmodels;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import org.geantlr.services.DynamicGrammar;
+
 public class MainViewModel {
 
     // Property to keep track of the number of active editors (1 or 2)
     private final IntegerProperty activeEditorsCount = new SimpleIntegerProperty(1);
+
+    // Property to hold the currently loaded dynamic grammar
+    private final ObjectProperty<DynamicGrammar> dynamicGrammar = new SimpleObjectProperty<>(null);
 
     public int getActiveEditorsCount() {
         return activeEditorsCount.get();
@@ -20,5 +27,17 @@ public class MainViewModel {
 
     public IntegerProperty activeEditorsCountProperty() {
         return activeEditorsCount;
+    }
+
+    public DynamicGrammar getDynamicGrammar() {
+        return dynamicGrammar.get();
+    }
+
+    public void setDynamicGrammar(DynamicGrammar grammar) {
+        this.dynamicGrammar.set(grammar);
+    }
+
+    public ObjectProperty<DynamicGrammar> dynamicGrammarProperty() {
+        return dynamicGrammar;
     }
 }

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -15,9 +15,15 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.stage.Stage;
 import javafx.fxml.FXMLLoader;
+import java.io.File;
 import java.io.IOException;
 import org.geantlr.viewmodels.MainViewModel;
+import org.geantlr.services.GrammarLoaderService;
+import org.geantlr.services.IGrammarLoaderService;
+import org.geantlr.services.DynamicGrammar;
 import org.kordamp.ikonli.javafx.FontIcon;
+import javafx.stage.FileChooser;
+import javafx.scene.control.Alert;
 
 public class MainViewController {
 
@@ -47,6 +53,7 @@ public class MainViewController {
 
     private MainViewModel viewModel;
     private boolean isDarkMode = true;
+    private IGrammarLoaderService grammarLoaderService;
 
     // Regions for editors
     private Region primaryEditor;
@@ -58,6 +65,7 @@ public class MainViewController {
     @FXML
     public void initialize() {
         viewModel = new MainViewModel();
+        grammarLoaderService = new GrammarLoaderService();
 
         // Use an accent button style if provided by AtlantaFX
         themeToggleBtn.getStyleClass().addAll("accent");
@@ -154,6 +162,41 @@ public class MainViewController {
             viewModel.setActiveEditorsCount(2);
         } else {
             viewModel.setActiveEditorsCount(1);
+        }
+    }
+
+    @FXML
+    private void loadGrammar() {
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Select ANTLR Grammar File");
+        fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("ANTLR Grammar (*.g4)", "*.g4"));
+
+        Stage stage = (Stage) titleBar.getScene().getWindow();
+        File selectedFile = fileChooser.showOpenDialog(stage);
+
+        if (selectedFile != null) {
+            try {
+                DynamicGrammar dynamicGrammar = grammarLoaderService.loadDynamicGrammar(selectedFile);
+                viewModel.setDynamicGrammar(dynamicGrammar);
+
+                Alert alert = new Alert(Alert.AlertType.INFORMATION);
+                alert.setTitle("Grammar Loaded");
+                alert.setHeaderText("Success");
+                String rulesMsg = dynamicGrammar.getParserGrammar() != null
+                    ? "Parser rules: " + dynamicGrammar.getParserGrammar().rules.size()
+                    : "Lexer rules only";
+
+                alert.setContentText("Grammar '" + selectedFile.getName() + "' loaded and compiled successfully.\n" +
+                                     rulesMsg);
+                alert.showAndWait();
+            } catch (Exception e) {
+                Alert alert = new Alert(Alert.AlertType.ERROR);
+                alert.setTitle("Error Loading Grammar");
+                alert.setHeaderText("Failed to load or compile grammar");
+                alert.setContentText(e.getMessage());
+                e.printStackTrace();
+                alert.showAndWait();
+            }
         }
     }
 

--- a/src/main/resources/org/geantlr/views/MainView.fxml
+++ b/src/main/resources/org/geantlr/views/MainView.fxml
@@ -45,6 +45,11 @@
                 <FontIcon iconLiteral="mdi2p-page-layout-body" iconSize="20"/>
             </graphic>
         </Button>
+        <Button text="Load Grammar" onAction="#loadGrammar">
+            <graphic>
+                <FontIcon iconLiteral="mdi2f-file-code-outline" iconSize="20"/>
+            </graphic>
+        </Button>
     </ToolBar>
 
     <SplitPane fx:id="editorSplitPane" VBox.vgrow="ALWAYS" dividerPositions="0.5">

--- a/src/test/java/org/geantlr/services/GrammarLoaderServiceTest.java
+++ b/src/test/java/org/geantlr/services/GrammarLoaderServiceTest.java
@@ -26,11 +26,11 @@ class GrammarLoaderServiceTest {
         tempDir = Files.createTempDirectory("grammarTest");
 
         // Create some dummy .g4 files and a .txt file
-        grammarFile1 = Files.createFile(tempDir.resolve("test1.g4"));
-        Files.writeString(grammarFile1, "grammar Test1;");
+        grammarFile1 = Files.createFile(tempDir.resolve("Test1.g4"));
+        Files.writeString(grammarFile1, "grammar Test1; a : 'b' ;");
 
-        grammarFile2 = Files.createFile(tempDir.resolve("test2.g4"));
-        Files.writeString(grammarFile2, "grammar Test2;");
+        grammarFile2 = Files.createFile(tempDir.resolve("Test2.g4"));
+        Files.writeString(grammarFile2, "grammar Test2; a : 'b' ;");
 
         textFile = Files.createFile(tempDir.resolve("notGrammar.txt"));
         Files.writeString(textFile, "just some text");
@@ -49,8 +49,8 @@ class GrammarLoaderServiceTest {
         List<Path> files = service.findGrammarFiles(tempDir.toFile());
 
         assertEquals(2, files.size(), "Should find exactly 2 grammar files");
-        assertTrue(files.contains(grammarFile1), "Should contain test1.g4");
-        assertTrue(files.contains(grammarFile2), "Should contain test2.g4");
+        assertTrue(files.contains(grammarFile1), "Should contain Test1.g4");
+        assertTrue(files.contains(grammarFile2), "Should contain Test2.g4");
     }
 
     @Test
@@ -72,13 +72,32 @@ class GrammarLoaderServiceTest {
     @Test
     void loadGrammarContent_ValidFile_ReturnsContent() throws IOException {
         String content = service.loadGrammarContent(grammarFile1.toFile());
-        assertEquals("grammar Test1;", content, "Content should match what was written");
+        assertEquals("grammar Test1; a : 'b' ;", content, "Content should match what was written");
     }
 
     @Test
     void loadGrammarContent_InvalidFile_ThrowsException() {
         assertThrows(IllegalArgumentException.class, () -> {
             service.loadGrammarContent(new File("nonexistent_file.g4"));
+        }, "Should throw exception for nonexistent file");
+    }
+
+    @Test
+    void loadDynamicGrammar_ValidFile_ReturnsDynamicGrammar() throws Exception {
+        DynamicGrammar grammar = service.loadDynamicGrammar(grammarFile1.toFile());
+
+        assertNotNull(grammar, "Should return a DynamicGrammar instance");
+        assertNotNull(grammar.getParserGrammar(), "Parser grammar should not be null");
+        assertNotNull(grammar.getLexerGrammar(), "Implicit lexer grammar should not be null");
+        assertEquals("Test1", grammar.getParserGrammar().name, "Grammar name should match");
+        assertEquals("Test1Lexer", grammar.getLexerGrammar().name, "Lexer grammar name should match");
+        assertTrue(grammar.getParserGrammar().rules.size() > 0, "Parser should have rules");
+    }
+
+    @Test
+    void loadDynamicGrammar_InvalidFile_ThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            service.loadDynamicGrammar(new File("nonexistent_file.g4"));
         }, "Should throw exception for nonexistent file");
     }
 }

--- a/src/test/java/org/geantlr/services/GrammarLoaderServiceTest.java
+++ b/src/test/java/org/geantlr/services/GrammarLoaderServiceTest.java
@@ -1,0 +1,84 @@
+package org.geantlr.services;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GrammarLoaderServiceTest {
+
+    private GrammarLoaderService service;
+    private Path tempDir;
+    private Path grammarFile1;
+    private Path grammarFile2;
+    private Path textFile;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        service = new GrammarLoaderService();
+        tempDir = Files.createTempDirectory("grammarTest");
+
+        // Create some dummy .g4 files and a .txt file
+        grammarFile1 = Files.createFile(tempDir.resolve("test1.g4"));
+        Files.writeString(grammarFile1, "grammar Test1;");
+
+        grammarFile2 = Files.createFile(tempDir.resolve("test2.g4"));
+        Files.writeString(grammarFile2, "grammar Test2;");
+
+        textFile = Files.createFile(tempDir.resolve("notGrammar.txt"));
+        Files.writeString(textFile, "just some text");
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        Files.deleteIfExists(grammarFile1);
+        Files.deleteIfExists(grammarFile2);
+        Files.deleteIfExists(textFile);
+        Files.deleteIfExists(tempDir);
+    }
+
+    @Test
+    void findGrammarFiles_ReturnsOnlyG4Files() {
+        List<Path> files = service.findGrammarFiles(tempDir.toFile());
+
+        assertEquals(2, files.size(), "Should find exactly 2 grammar files");
+        assertTrue(files.contains(grammarFile1), "Should contain test1.g4");
+        assertTrue(files.contains(grammarFile2), "Should contain test2.g4");
+    }
+
+    @Test
+    void findGrammarFiles_EmptyDirectory_ReturnsEmptyList() throws IOException {
+        Path emptyDir = Files.createTempDirectory("emptyTest");
+        List<Path> files = service.findGrammarFiles(emptyDir.toFile());
+
+        assertTrue(files.isEmpty(), "Should return empty list for empty directory");
+        Files.deleteIfExists(emptyDir);
+    }
+
+    @Test
+    void findGrammarFiles_InvalidDirectory_ReturnsEmptyList() {
+        List<Path> files = service.findGrammarFiles(new File("nonexistent_directory"));
+
+        assertTrue(files.isEmpty(), "Should return empty list for nonexistent directory");
+    }
+
+    @Test
+    void loadGrammarContent_ValidFile_ReturnsContent() throws IOException {
+        String content = service.loadGrammarContent(grammarFile1.toFile());
+        assertEquals("grammar Test1;", content, "Content should match what was written");
+    }
+
+    @Test
+    void loadGrammarContent_InvalidFile_ThrowsException() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            service.loadGrammarContent(new File("nonexistent_file.g4"));
+        }, "Should throw exception for nonexistent file");
+    }
+}


### PR DESCRIPTION
This PR resolves Epic 3 Task 3.1: Dynamischer Grammatik-Loader.
It introduces a service layer to scan for and read ANTLR `.g4` grammar files.
Test coverage is included via JUnit 5.

---
*PR created automatically by Jules for task [17380128439888378873](https://jules.google.com/task/17380128439888378873) started by @tkpixel*