### PR TITLE
feat(editor): implement programmatic text insertion via mediator

### DIFF
--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -2,6 +2,8 @@ package org.geantlr.viewmodels;
 
 import io.micronaut.context.annotation.Prototype;
 import jakarta.inject.Inject;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
@@ -21,6 +23,10 @@ public class EditorViewModel {
     private final StringProperty textContent = new SimpleStringProperty("");
     private final ObservableList<SyntaxError> errors = FXCollections.observableArrayList();
     private final ObservableList<String> suggestedTokens = FXCollections.observableArrayList();
+
+    public record InsertTextCommand(String text) {}
+
+    private final ObjectProperty<InsertTextCommand> insertTextCommand = new SimpleObjectProperty<>();
 
     private final AntlrGrammarService antlrGrammarService;
     private final CodeCompletionService codeCompletionService;
@@ -74,6 +80,21 @@ public class EditorViewModel {
 
     public ObservableList<String> getSuggestedTokens() {
         return suggestedTokens;
+    }
+
+    public ObjectProperty<InsertTextCommand> insertTextCommandProperty() {
+        return insertTextCommand;
+    }
+
+    public void insertBaustein(String token) {
+        String cleanToken = token.startsWith("'") && token.endsWith("'")
+                ? token.substring(1, token.length() - 1)
+                : token;
+        insertTextCommand.set(new InsertTextCommand(cleanToken));
+    }
+
+    public void clearInsertTextCommand() {
+        insertTextCommand.set(null);
     }
 
     public void onCaretPositionChanged(int caretPosition) {

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -57,6 +57,16 @@ public class EditorViewController {
                 }
             });
 
+            // Listen to insert text command
+            this.viewModel.insertTextCommandProperty().addListener((obs, oldVal, newVal) -> {
+                if (newVal != null) {
+                    editorCodeArea.insertText(editorCodeArea.getCaretPosition(), newVal.text() + " ", null);
+                    editorCodeArea.requestFocus();
+                    // Clear the command in ViewModel to allow repeated commands
+                    this.viewModel.clearInsertTextCommand();
+                }
+            });
+
             // Listen to error changes
             this.viewModel.getErrors().addListener((ListChangeListener<SyntaxError>) c -> {
                 // Trigger a full redraw to apply syntax decorations
@@ -80,14 +90,9 @@ public class EditorViewController {
                 for (String token : this.viewModel.getSuggestedTokens()) {
                     Button btn = new Button(token);
                     btn.getStyleClass().addAll("pill-button");
-                    // On click, append text (simple demo action)
+                    // On click, append text via the view model mediator
                     btn.setOnAction(e -> {
-                        String cleanToken = token.startsWith("'") && token.endsWith("'")
-                                ? token.substring(1, token.length() - 1)
-                                : token;
-                        // Insert at caret position logic can be improved later
-                        editorCodeArea.insertText(editorCodeArea.getCaretPosition(), cleanToken + " ", null);
-                        editorCodeArea.requestFocus();
+                        viewModel.insertBaustein(token);
                     });
                     suggestionsPane.getChildren().add(btn);
                 }


### PR DESCRIPTION
Implements Epic 5, Task 5.1: Bidirectional synchronization to allow programmatic insertion of text tokens ("Bausteine"). The ViewModel now acts as a mediator, emitting a command to the Controller, ensuring that insertions correctly utilize the CodeArea's native Undo/Redo mechanisms without triggering infinite binding loops.

---
*PR created automatically by Jules for task [6034968511264644595](https://jules.google.com/task/6034968511264644595) started by @tkpixel*