### PR TITLE
Task 5.2: Vermeidung von Endlosschleifen - Guard-Flags und Fokus-Rückgabe

### DIFF
--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -28,6 +28,8 @@ public class EditorViewModel {
 
     private final ObjectProperty<InsertTextCommand> insertTextCommand = new SimpleObjectProperty<>();
 
+    private boolean isUpdating = false;
+
     private final AntlrGrammarService antlrGrammarService;
     private final CodeCompletionService codeCompletionService;
     private final MainViewModel mainViewModel;
@@ -86,10 +88,19 @@ public class EditorViewModel {
         return insertTextCommand;
     }
 
+    public boolean isUpdating() {
+        return isUpdating;
+    }
+
+    public void setUpdating(boolean updating) {
+        isUpdating = updating;
+    }
+
     public void insertBaustein(String token) {
         String cleanToken = token.startsWith("'") && token.endsWith("'")
                 ? token.substring(1, token.length() - 1)
                 : token;
+        setUpdating(true);
         insertTextCommand.set(new InsertTextCommand(cleanToken));
     }
 

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -44,7 +44,9 @@ public class EditorViewController {
 
             // Update view model when CodeArea text changes
             editorCodeArea.getModel().addListener(change -> {
-                this.viewModel.setTextContent(editorCodeArea.getText());
+                if (!this.viewModel.isUpdating()) {
+                    this.viewModel.setTextContent(editorCodeArea.getText());
+                }
             });
 
             // Set initial text
@@ -60,10 +62,19 @@ public class EditorViewController {
             // Listen to insert text command
             this.viewModel.insertTextCommandProperty().addListener((obs, oldVal, newVal) -> {
                 if (newVal != null) {
-                    editorCodeArea.insertText(editorCodeArea.getCaretPosition(), newVal.text() + " ", null);
-                    editorCodeArea.requestFocus();
-                    // Clear the command in ViewModel to allow repeated commands
-                    this.viewModel.clearInsertTextCommand();
+                    try {
+                        TextPos currentPos = editorCodeArea.getCaretPosition();
+                        editorCodeArea.insertText(currentPos, newVal.text() + " ", null);
+
+                        int newOffset = currentPos.offset() + newVal.text().length() + 1;
+                        editorCodeArea.select(TextPos.ofLeading(newOffset, newOffset));
+
+                        editorCodeArea.requestFocus();
+                    } finally {
+                        // Clear the command in ViewModel to allow repeated commands
+                        this.viewModel.clearInsertTextCommand();
+                        this.viewModel.setUpdating(false);
+                    }
                 }
             });
 


### PR DESCRIPTION
Implemented the Guard-Flags and Focus-Rückgabe task (5.2).

The changes introduce a `boolean isUpdating` flag in `EditorViewModel` that gets set right before text gets inserted into the model. The `EditorViewController` checks this flag before triggering further validation loops. 
Furthermore, the text insertion process restores the cursor to precisely after the inserted text and re-requests focus for a seamless user experience. Tests have been executed to ensure nothing is broken.

---
*PR created automatically by Jules for task [1473881738279127788](https://jules.google.com/task/1473881738279127788) started by @tkpixel*