### PR TITLE
Update auto-completion to trigger immediately on text changes

### DIFF
--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -36,6 +36,7 @@ public class EditorViewModel {
     private final ObjectProperty<InsertTextCommand> insertTextCommand = new SimpleObjectProperty<>();
 
     private boolean isUpdating = false;
+    private int currentCaretPosition = 0;
 
     private final AntlrGrammarService antlrGrammarService;
     private final CodeCompletionService codeCompletionService;
@@ -53,6 +54,7 @@ public class EditorViewModel {
 
         textContent.addListener((obs, oldVal, newVal) -> {
             debounce.playFromStart();
+            updateSuggestions();
         });
     }
 
@@ -181,13 +183,19 @@ public class EditorViewModel {
     }
 
     public void onCaretPositionChanged(int caretPosition) {
+        this.currentCaretPosition = caretPosition;
+        updateSuggestions();
+    }
+
+    private void updateSuggestions() {
         var grammar = mainViewModel.getDynamicGrammar();
         if (grammar == null) {
             Platform.runLater(suggestedTokens::clear);
             return;
         }
         String text = textContent.get();
-        List<String> suggestions = codeCompletionService.getSuggestedTokens(grammar, text, caretPosition);
-        Platform.runLater(() -> suggestedTokens.setAll(suggestions));
+        int caretPosition = this.currentCaretPosition;
+        CompletableFuture.supplyAsync(() -> codeCompletionService.getSuggestedTokens(grammar, text, caretPosition))
+            .thenAccept(suggestions -> Platform.runLater(() -> suggestedTokens.setAll(suggestions)));
     }
 }

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -78,6 +78,7 @@ public class EditorViewController {
                         // Clear the command in ViewModel to allow repeated commands
                         this.viewModel.clearInsertTextCommand();
                         this.viewModel.setUpdating(false);
+                        this.viewModel.setTextContent(editorCodeArea.getText());
                     }
                 }
             });


### PR DESCRIPTION
Closes an issue where keyword suggestions from ANTLR completion core were only updating after a caret movement. They now refresh instantly upon typing or immediately after inserting a completion block.

---
*PR created automatically by Jules for task [4292657457304947429](https://jules.google.com/task/4292657457304947429) started by @tkpixel*