### PR TITLE
Style token buttons using primary accent color

### DIFF
--- a/src/main/resources/org/geantlr/theme.css
+++ b/src/main/resources/org/geantlr/theme.css
@@ -106,11 +106,23 @@
 .pill-button {
     -fx-background-radius: 15px;
     -fx-border-radius: 15px;
-    -fx-text-fill: -color-fg-default;
+    -fx-background-color: -color-accent-emphasis;
+    -fx-text-fill: white;
+}
+
+.pill-button:hover {
+    -fx-background-color: derive(-color-accent-emphasis, -10%);
 }
 
 .pill-button:focused {
     -fx-background-radius: 15px;
     -fx-border-radius: 15px;
-    -fx-text-fill: -color-fg-default;
+    -fx-background-color: -color-accent-emphasis;
+    -fx-text-fill: white;
+    -fx-border-color: derive(-color-accent-emphasis, 20%);
+    -fx-border-width: 2px;
+}
+
+.pill-button:armed {
+    -fx-background-color: derive(-color-accent-emphasis, -20%);
 }


### PR DESCRIPTION
The user requested that the token buttons be styled in the primary color.

1.  **Explored the codebase:** Found that the token suggestion buttons are created in `EditorViewController.java` and assigned the CSS class `pill-button`.
2.  **Identified the primary color:** The primary/accent color is defined in `theme.css` as `-color-accent-emphasis`.
3.  **Modified `theme.css`:** Updated `.pill-button` to set `-fx-background-color` to `-color-accent-emphasis` and `-fx-text-fill` to `white`. Added interactive pseudo-classes (`:hover`, `:focused`, `:armed`) utilizing the JavaFX `derive()` function to darken/lighten the base color for visual feedback.
4.  **Tested the application:** Ran `mvn test` to ensure there are no regressions.
5.  **Verified the frontend:** Wrote a Python script utilizing Xvfb and Imagemagick to launch the JavaFX application and take a visual screenshot to confirm functionality in a headless environment.
6.  **Passed code review:** Code review confirmed the implementation correctly solves the user's request.

---
*PR created automatically by Jules for task [3567445241345178890](https://jules.google.com/task/3567445241345178890) started by @tkpixel*