### PR TITLE
Add auto-formatting using ANTLR4 TokenStreamRewriter

### DIFF
--- a/InspectCodeTextModel.java
+++ b/InspectCodeTextModel.java
@@ -1,0 +1,11 @@
+import jfx.incubator.scene.control.richtext.model.CodeTextModel;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class InspectCodeTextModel {
+    public static void main(String[] args) throws Exception {
+        for (Method m : Class.forName("jfx.incubator.scene.control.richtext.model.StyledTextModel").getMethods()) {
+            System.out.println(m.getName());
+        }
+    }
+}

--- a/InspectTextPos.java
+++ b/InspectTextPos.java
@@ -1,0 +1,11 @@
+import jfx.incubator.scene.control.richtext.model.CodeTextModel;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class InspectTextPos {
+    public static void main(String[] args) {
+        for (Method m : CodeTextModel.class.getMethods()) {
+            System.out.println(m);
+        }
+    }
+}

--- a/pom_dependency_fetch.xml
+++ b/pom_dependency_fetch.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.geantlr.test</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0</version>
+    <dependencies>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>jfx-incubator-richtext</artifactId>
+            <version>25-ea+21</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/org/geantlr/services/CodeFormattingService.java
+++ b/src/main/java/org/geantlr/services/CodeFormattingService.java
@@ -1,0 +1,135 @@
+package org.geantlr.services;
+
+import jakarta.inject.Singleton;
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.LexerInterpreter;
+import org.antlr.v4.runtime.ParserInterpreter;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.TokenStreamRewriter;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.antlr.v4.runtime.tree.ErrorNode;
+import org.antlr.v4.runtime.ParserRuleContext;
+
+@Singleton
+public class CodeFormattingService {
+
+    public String formatCode(DynamicGrammar grammar, String code) {
+        if (grammar == null || grammar.getParserGrammar() == null || code == null || code.isEmpty()) {
+            return code;
+        }
+
+        CharStream input = CharStreams.fromString(code);
+        LexerInterpreter lexerInterpreter = grammar.createLexerInterpreter(input);
+        lexerInterpreter.removeErrorListeners();
+
+        CommonTokenStream tokenStream = new CommonTokenStream(lexerInterpreter);
+        tokenStream.fill();
+
+        ParserInterpreter parserInterpreter = grammar.createParserInterpreter(tokenStream);
+        parserInterpreter.removeErrorListeners();
+
+        org.antlr.v4.tool.Rule startRule = grammar.getParserGrammar().rules.values().iterator().next();
+        ParseTree tree;
+        try {
+            tree = parserInterpreter.parse(startRule.index);
+        } catch (Exception e) {
+            return code; // Fallback on parse error
+        }
+
+        TokenStreamRewriter rewriter = new TokenStreamRewriter(tokenStream);
+
+        ParseTreeWalker walker = new ParseTreeWalker();
+        FormatterListener listener = new FormatterListener(rewriter, tokenStream);
+        walker.walk(listener, tree);
+
+        return rewriter.getText();
+    }
+
+    private static class FormatterListener implements ParseTreeListener {
+        private final TokenStreamRewriter rewriter;
+        private final CommonTokenStream tokenStream;
+        private int indentLevel = 0;
+        private boolean needsIndent = false;
+
+        public FormatterListener(TokenStreamRewriter rewriter, CommonTokenStream tokenStream) {
+            this.rewriter = rewriter;
+            this.tokenStream = tokenStream;
+        }
+
+        private String getIndentString() {
+            return "    ".repeat(Math.max(0, indentLevel));
+        }
+
+        @Override
+        public void visitTerminal(TerminalNode node) {
+            Token token = node.getSymbol();
+
+            // Remove previous hidden whitespace tokens (keep comments if they are on a different channel or identifiable, though ANTLR handles this differently per grammar; we'll only delete whitespaces if we can identify them)
+            // For a robust generic formatter, we should look for tokens that consist only of whitespace
+            int tokenIndex = token.getTokenIndex();
+            java.util.List<Token> hiddenTokens = tokenStream.getHiddenTokensToLeft(tokenIndex);
+            if (hiddenTokens != null) {
+                for (Token hidden : hiddenTokens) {
+                    if (hidden.getType() != Token.EOF && hidden.getText() != null && hidden.getText().trim().isEmpty()) {
+                        rewriter.delete(hidden);
+                    }
+                }
+            }
+
+            String text = token.getText();
+            if (text == null) return;
+
+            if (text.equals("}") || text.equals("]")) {
+                indentLevel--;
+                rewriter.insertBefore(token, "\n" + getIndentString());
+                needsIndent = false;
+            } else if (needsIndent) {
+                rewriter.insertBefore(token, getIndentString());
+                needsIndent = false;
+            }
+
+            if (text.equals("{") || text.equals("[")) {
+                indentLevel++;
+                rewriter.insertAfter(token, "\n");
+                needsIndent = true;
+            } else if (text.equals(";") || text.equals(",")) {
+                rewriter.insertAfter(token, "\n");
+                needsIndent = true;
+            } else if (!text.equals("}") && !text.equals("]")) {
+                // Ensure spaces between normal tokens unless followed by punctuation
+                // Find next non-whitespace hidden token, or next visible token
+                Token nextVisibleToken = null;
+                for (int i = tokenIndex + 1; i < tokenStream.size(); i++) {
+                    Token t = tokenStream.get(i);
+                    if (t.getChannel() == Token.DEFAULT_CHANNEL) {
+                        nextVisibleToken = t;
+                        break;
+                    }
+                }
+
+                if (nextVisibleToken != null && nextVisibleToken.getType() != Token.EOF) {
+                    String nextText = nextVisibleToken.getText();
+                    if (nextText != null && !nextText.equals(";") && !nextText.equals(",") &&
+                        !nextText.equals(".") && !nextText.equals(")") &&
+                        !nextText.equals("]") && !nextText.equals("}")) {
+                        rewriter.insertAfter(token, " ");
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void visitErrorNode(ErrorNode node) {}
+
+        @Override
+        public void enterEveryRule(ParserRuleContext ctx) {}
+
+        @Override
+        public void exitEveryRule(ParserRuleContext ctx) {}
+    }
+}

--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -10,6 +10,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import org.geantlr.services.AntlrGrammarService;
 import org.geantlr.services.CodeCompletionService;
+import org.geantlr.services.CodeFormattingService;
 import org.geantlr.services.ParseResult;
 import org.geantlr.services.SyntaxError;
 import org.antlr.v4.runtime.Token;
@@ -40,14 +41,19 @@ public class EditorViewModel {
 
     private final AntlrGrammarService antlrGrammarService;
     private final CodeCompletionService codeCompletionService;
+    private final CodeFormattingService codeFormattingService;
     private final MainViewModel mainViewModel;
 
     private final PauseTransition debounce = new PauseTransition(Duration.millis(300));
 
+    public record ReplaceTextCommand(String text) {}
+    private final ObjectProperty<ReplaceTextCommand> replaceTextCommand = new SimpleObjectProperty<>();
+
     @Inject
-    public EditorViewModel(AntlrGrammarService antlrGrammarService, CodeCompletionService codeCompletionService, MainViewModel mainViewModel) {
+    public EditorViewModel(AntlrGrammarService antlrGrammarService, CodeCompletionService codeCompletionService, CodeFormattingService codeFormattingService, MainViewModel mainViewModel) {
         this.antlrGrammarService = antlrGrammarService;
         this.codeCompletionService = codeCompletionService;
+        this.codeFormattingService = codeFormattingService;
         this.mainViewModel = mainViewModel;
 
         debounce.setOnFinished(event -> parseText(textContent.get()));
@@ -160,6 +166,30 @@ public class EditorViewModel {
 
     public ObjectProperty<InsertTextCommand> insertTextCommandProperty() {
         return insertTextCommand;
+    }
+
+    public ObjectProperty<ReplaceTextCommand> replaceTextCommandProperty() {
+        return replaceTextCommand;
+    }
+
+    public void clearReplaceTextCommand() {
+        replaceTextCommand.set(null);
+    }
+
+    public void formatCode() {
+        var grammar = mainViewModel.getDynamicGrammar();
+        if (grammar == null) return;
+
+        String currentText = textContent.get();
+        CompletableFuture.supplyAsync(() -> codeFormattingService.formatCode(grammar, currentText))
+            .thenAccept(formattedText -> {
+                Platform.runLater(() -> {
+                    if (formattedText != null && !formattedText.equals(currentText)) {
+                        setUpdating(true);
+                        replaceTextCommand.set(new ReplaceTextCommand(formattedText));
+                    }
+                });
+            });
     }
 
     public boolean isUpdating() {

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -4,6 +4,9 @@ import io.micronaut.context.annotation.Prototype;
 import jakarta.inject.Inject;
 import javafx.collections.ListChangeListener;
 import javafx.fxml.FXML;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
+import javafx.scene.input.KeyCombination;
 import javafx.scene.paint.Color;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.control.Button;
@@ -38,6 +41,19 @@ public class EditorViewController {
     public void initialize() {
         if (editorCodeArea != null) {
             editorCodeArea.setLineNumbersEnabled(true);
+
+            editorCodeArea.sceneProperty().addListener((obs, oldScene, newScene) -> {
+                if (newScene != null) {
+                    newScene.getAccelerators().put(
+                        new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN),
+                        () -> {
+                            if (this.viewModel != null) {
+                                this.viewModel.formatCode();
+                            }
+                        }
+                    );
+                }
+            });
         }
     }
 
@@ -60,6 +76,22 @@ public class EditorViewController {
             this.viewModel.textContentProperty().addListener((obs, oldVal, newVal) -> {
                 if (!newVal.equals(editorCodeArea.getText())) {
                     editorCodeArea.setText(newVal);
+                }
+            });
+
+            // Listen to replace text command for formatting
+            this.viewModel.replaceTextCommandProperty().addListener((obs, oldVal, newVal) -> {
+                if (newVal != null) {
+                    try {
+                        // replaceText applies a single action to the undo stack
+                        // Using 'false' for 'preserveStyle' parameter
+                        int lastParagraph = editorCodeArea.getModel().size() - 1;
+                        editorCodeArea.replaceText(TextPos.ofLeading(0, 0), TextPos.ofLeading(lastParagraph, editorCodeArea.getModel().getPlainText(lastParagraph).length()), newVal.text(), false);
+                    } finally {
+                        this.viewModel.clearReplaceTextCommand();
+                        this.viewModel.setUpdating(false);
+                        this.viewModel.setTextContent(editorCodeArea.getText());
+                    }
                 }
             });
 


### PR DESCRIPTION
Adds auto-formatting (pretty printing) via Ctrl+Shift+F shortcut for ANTLR grammars in the editor view, maintaining undo/redo capabilities.

---
*PR created automatically by Jules for task [9094187390579292560](https://jules.google.com/task/9094187390579292560) started by @tkpixel*