### PR TITLE
🏛️ Archie: [MVVM refactoring] Remove domain service coupling from View

### DIFF
--- a/.jules/archie.md
+++ b/.jules/archie.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - [View Controllers Bypassing ViewModels]
+**Learning:** Found a pattern where JavaFX Controllers inject and directly call Micronaut domain services (like `IGrammarLoaderService`), bypassing the ViewModel layer. This breaks MVVM separation of concerns, as the View should only communicate with the ViewModel.
+**Action:** When inspecting controllers, ensure they only inject their respective ViewModels (and context for initial loading if strictly necessary) and delegate all business logic requests and domain service calls to the ViewModel instead.

--- a/src/main/java/org/geantlr/viewmodels/MainViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/MainViewModel.java
@@ -8,10 +8,15 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import jakarta.inject.Singleton;
+import jakarta.inject.Inject;
 import org.geantlr.services.DynamicGrammar;
+import org.geantlr.services.IGrammarLoaderService;
+import java.io.File;
 
 @Singleton
 public class MainViewModel {
+
+    private final IGrammarLoaderService grammarLoaderService;
 
     // Property to keep track of the active editors
     private final ObservableList<EditorViewModel> activeEditors = FXCollections.observableArrayList();
@@ -21,6 +26,11 @@ public class MainViewModel {
 
     // Property to toggle experimental mode
     private final javafx.beans.property.BooleanProperty experimentalMode = new javafx.beans.property.SimpleBooleanProperty(false);
+
+    @Inject
+    public MainViewModel(IGrammarLoaderService grammarLoaderService) {
+        this.grammarLoaderService = grammarLoaderService;
+    }
 
     public ObservableList<EditorViewModel> getActiveEditors() {
         return activeEditors;
@@ -58,5 +68,24 @@ public class MainViewModel {
 
     public void setExperimentalMode(boolean isExperimentalMode) {
         this.experimentalMode.set(isExperimentalMode);
+    }
+
+    // Archie: Added these delegate methods to improve MVVM separation.
+    // The View should never talk directly to a Micronaut Domain Service (IGrammarLoaderService).
+    // All business logic requests must flow through the ViewModel.
+    public void addImportDirectory(File directory) {
+        grammarLoaderService.addImportDirectory(directory);
+    }
+
+    public void clearImportDirectories() {
+        grammarLoaderService.clearImportDirectories();
+    }
+
+    public int getImportDirectoriesCount() {
+        return grammarLoaderService.getImportDirectories().size();
+    }
+
+    public DynamicGrammar loadDynamicGrammar(File grammarFile) throws Exception {
+        return grammarLoaderService.loadDynamicGrammar(grammarFile);
     }
 }

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -47,7 +47,6 @@ public class MainViewController {
     private FontIcon themeIcon;
 
     private final MainViewModel viewModel;
-    private final IGrammarLoaderService grammarLoaderService;
     private final ApplicationContext context;
 
     private boolean isDarkMode = true;
@@ -56,9 +55,8 @@ public class MainViewController {
     private final Map<EditorViewModel, Region> editorRegions = new HashMap<>();
 
     @Inject
-    public MainViewController(MainViewModel viewModel, IGrammarLoaderService grammarLoaderService, ApplicationContext context) {
+    public MainViewController(MainViewModel viewModel, ApplicationContext context) {
         this.viewModel = viewModel;
-        this.grammarLoaderService = grammarLoaderService;
         this.context = context;
     }
 
@@ -131,11 +129,11 @@ public class MainViewController {
 
         if (selectedDir != null) {
             try {
-                grammarLoaderService.addImportDirectory(selectedDir);
+                viewModel.addImportDirectory(selectedDir);
                 Alert alert = new Alert(Alert.AlertType.INFORMATION);
                 alert.setTitle("Import Directory Added");
                 alert.setHeaderText("Success");
-                alert.setContentText("Added directory '" + selectedDir.getName() + "' for resolving imported grammars.\nTotal import directories: " + grammarLoaderService.getImportDirectories().size());
+                alert.setContentText("Added directory '" + selectedDir.getName() + "' for resolving imported grammars.\nTotal import directories: " + viewModel.getImportDirectoriesCount());
                 alert.showAndWait();
             } catch (Exception e) {
                 Alert alert = new Alert(Alert.AlertType.ERROR);
@@ -149,7 +147,7 @@ public class MainViewController {
 
     @FXML
     private void clearImportDirectories() {
-        grammarLoaderService.clearImportDirectories();
+        viewModel.clearImportDirectories();
         Alert alert = new Alert(Alert.AlertType.INFORMATION);
         alert.setTitle("Import Directories Cleared");
         alert.setHeaderText("Success");
@@ -168,7 +166,7 @@ public class MainViewController {
 
         if (selectedFile != null) {
             try {
-                DynamicGrammar dynamicGrammar = grammarLoaderService.loadDynamicGrammar(selectedFile);
+                DynamicGrammar dynamicGrammar = viewModel.loadDynamicGrammar(selectedFile);
                 viewModel.setDynamicGrammar(dynamicGrammar);
 
                 Alert alert = new Alert(Alert.AlertType.INFORMATION);


### PR DESCRIPTION
💡 What: Refactored `MainViewController` and `MainViewModel` to remove the direct injection of `IGrammarLoaderService` into the View. The service is now correctly injected into the ViewModel, which provides delegate methods for the View.
🎯 Why: Fixes an MVVM violation where the View directly interacts with a Micronaut domain service. The View should only communicate with the ViewModel.
🧪 Testability: Makes the View strictly dependent on the ViewModel, making the application's flow easier to mock and test without needing to provide domain services to the UI components directly.

---
*PR created automatically by Jules for task [686003788592682074](https://jules.google.com/task/686003788592682074) started by @tkpixel*