### PR TITLE
🎨 Palette: Accessible Icon-Only Toolbar Buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [Accessible Icon Buttons]
+**Learning:** When using AtlantaFX, removing text from buttons to save space requires adding `atlantafx.base.theme.Styles.BUTTON_ICON` to the style classes. More importantly, removing the text breaks screen reader support, so `setAccessibleText`, `setAccessibleHelp`, and a `Tooltip` must be explicitly added to maintain accessibility and provide visual hover context.
+**Action:** When creating icon-only buttons, always apply `Styles.BUTTON_ICON` and immediately add `setAccessibleText()`, `setAccessibleHelp()`, and `setTooltip()`.

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -41,6 +41,9 @@ public class MainViewController {
     private SplitPane editorSplitPane;
 
     @FXML
+    private Button toggleEditorsBtn;
+
+    @FXML
     private Button themeToggleBtn;
 
     @FXML
@@ -63,7 +66,17 @@ public class MainViewController {
     @FXML
     public void initialize() {
         // Use an accent button style if provided by AtlantaFX
-        themeToggleBtn.getStyleClass().addAll("accent");
+        themeToggleBtn.getStyleClass().addAll("accent", atlantafx.base.theme.Styles.BUTTON_ICON);
+        themeToggleBtn.setAccessibleText("Toggle Theme");
+        themeToggleBtn.setAccessibleHelp("Switches between light and dark themes.");
+        themeToggleBtn.setTooltip(new javafx.scene.control.Tooltip("Toggle Theme"));
+
+        if (toggleEditorsBtn != null) {
+            toggleEditorsBtn.getStyleClass().addAll(atlantafx.base.theme.Styles.BUTTON_ICON);
+            toggleEditorsBtn.setAccessibleText("Toggle Editors");
+            toggleEditorsBtn.setAccessibleHelp("Switches between single and split editor views.");
+            toggleEditorsBtn.setTooltip(new javafx.scene.control.Tooltip("Toggle Editors"));
+        }
 
         // Listen to active editors list
         viewModel.getActiveEditors().addListener((ListChangeListener<EditorViewModel>) change -> {

--- a/src/main/resources/org/geantlr/views/MainView.fxml
+++ b/src/main/resources/org/geantlr/views/MainView.fxml
@@ -46,12 +46,12 @@
                 <!-- Spacer -->
                 <HBox HBox.hgrow="ALWAYS" />
 
-                <Button text="Toggle Editors" onAction="#toggleEditors">
+                <Button fx:id="toggleEditorsBtn" onAction="#toggleEditors">
                     <graphic>
                         <FontIcon iconLiteral="mdi2p-page-layout-body" iconSize="20"/>
                     </graphic>
                 </Button>
-                <Button fx:id="themeToggleBtn" text="Toggle Theme" onAction="#toggleTheme">
+                <Button fx:id="themeToggleBtn" onAction="#toggleTheme">
                     <graphic>
                         <FontIcon fx:id="themeIcon" iconLiteral="mdi2w-white-balance-sunny" iconSize="20"/>
                     </graphic>


### PR DESCRIPTION
💡 What: The UX enhancement changes the 'Toggle Theme' and 'Toggle Editors' toolbar buttons to be icon-only to save horizontal space. 

🎯 Why: To reduce UI clutter in the top toolbar while preserving usability and fully maintaining screen reader accessibility, which would otherwise be broken when removing button text.

♿ Accessibility: Added `setAccessibleText` and `setAccessibleHelp` specifically to ensure these icon buttons read aloud properly for screen readers. Added `setTooltip` to provide on-hover context for sighted users.

---
*PR created automatically by Jules for task [3250351809688609793](https://jules.google.com/task/3250351809688609793) started by @tkpixel*