### PR TITLE
⚡ Bolt: Optimize regex splitting and offload I/O to Virtual Threads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Optimize regex splitting in hot loop
+**Learning:** In `EditorViewModel.computeTokenStyles`, calling `text.split("\r?\n", -1)` for every single token introduced severe overhead due to unnecessary regex compilation and array allocations in a hot loop that executes on every keystroke, especially since most tokens are single-line.
+**Action:** Implement a fast-path check `text.indexOf('\n') == -1` to avoid the regex evaluation entirely for single-line tokens.

--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -154,16 +154,25 @@ public class EditorViewModel {
             int startLine = token.getLine();
             int startCharPos = token.getCharPositionInLine();
 
-            String[] lines = text.split("\r?\n", -1);
+            // ⚡ Bolt: Fast-path optimization to avoid expensive regex/split for single-line strings
+            if (text.indexOf('\n') == -1) {
+                int endInLine = startCharPos + text.length();
+                if (startCharPos < endInLine) {
+                    styles.computeIfAbsent(startLine, k -> new java.util.ArrayList<>())
+                          .add(new TokenStyle(startCharPos, endInLine, symbolicName));
+                }
+            } else {
+                String[] lines = text.split("\r?\n", -1);
 
-            for (int i = 0; i < lines.length; i++) {
-                int currentLine = startLine + i;
-                int startInLine = (i == 0) ? startCharPos : 0;
-                int endInLine = startInLine + lines[i].length();
+                for (int i = 0; i < lines.length; i++) {
+                    int currentLine = startLine + i;
+                    int startInLine = (i == 0) ? startCharPos : 0;
+                    int endInLine = startInLine + lines[i].length();
 
-                if (startInLine < endInLine) {
-                    styles.computeIfAbsent(currentLine, k -> new java.util.ArrayList<>())
-                          .add(new TokenStyle(startInLine, endInLine, symbolicName));
+                    if (startInLine < endInLine) {
+                        styles.computeIfAbsent(currentLine, k -> new java.util.ArrayList<>())
+                              .add(new TokenStyle(startInLine, endInLine, symbolicName));
+                    }
                 }
             }
         }
@@ -339,6 +348,7 @@ public class EditorViewModel {
             }
         });
 
-        new Thread(generationTask).start();
+        // ⚡ Bolt: Offload blocking I/O from heavy OS threads to Virtual Threads
+        Thread.ofVirtual().start(generationTask);
     }
 }

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -198,15 +198,16 @@ public class EditorViewController {
                 }
             });
 
+            // ⚡ Bolt: Use InvalidationListener instead of ListChangeListener to avoid eager difference computation
             // Listen to error changes
-            this.viewModel.getErrors().addListener((ListChangeListener<SyntaxError>) c -> {
+            this.viewModel.getErrors().addListener((javafx.beans.InvalidationListener) obs -> {
                 // Trigger a full redraw to apply syntax decorations
                 editorCodeArea.setSyntaxDecorator(null);
                 editorCodeArea.setSyntaxDecorator(createSyntaxDecorator());
             });
 
             // Listen to token changes for highlighting
-            this.viewModel.getTokens().addListener((ListChangeListener<Token>) c -> {
+            this.viewModel.getTokens().addListener((javafx.beans.InvalidationListener) obs -> {
                 editorCodeArea.setSyntaxDecorator(null);
                 editorCodeArea.setSyntaxDecorator(createSyntaxDecorator());
             });


### PR DESCRIPTION
💡 **What:** 
1. Added a fast-path `text.indexOf('\n') == -1` check in `EditorViewModel.computeTokenStyles` to skip regex splitting for single-line tokens.
2. Modified `generateRuleFromText` to run on a Java 25 Virtual Thread (`Thread.ofVirtual().start()`) instead of an OS Thread.
3. Changed `ListChangeListener` to `InvalidationListener` in `EditorViewController` for `errors` and `tokens`.
4. Created `.jules/bolt.md` with performance learnings.

🎯 **Why:** 
1. The regex compilation and string array allocation in `text.split("\r?\n")` occurred on every single token during a hot loop triggered by every keystroke. Since the vast majority of tokens are single-line, this was a massive waste of CPU and memory.
2. Background OS threads are heavy; since the LLM generation task is blocking I/O waiting for Ollama to respond, a Virtual Thread is vastly more efficient and scalable.
3. The UI only uses list changes to trigger a full syntax decorator redraw, so computing the eager list permutation differences via `ListChangeListener` was wasted CPU overhead.

📊 **Impact:** 
- Eliminates unnecessary object allocations and GC pressure during real-time typing in the editor.
- Reduces memory footprint for background generation tasks.
- Avoids CPU overhead of computing list diffs when they are simply thrown away.

🔬 **Measurement:** 
- Run `export JAVA_HOME=/usr/lib/jvm/java-25-openjdk-amd64 && mvn clean verify`
- Typing rapidly in the `EditorCodeArea` should reflect fewer GC pauses in a profiler.

---
*PR created automatically by Jules for task [2571599681558462921](https://jules.google.com/task/2571599681558462921) started by @tkpixel*