### PR TITLE
Configure executable jar via maven-shade-plugin

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,25 @@
+# Building geANTLR
+
+geANTLR uses Maven for dependency management and building.
+
+## Requirements
+*   **Java 25:** This project requires JDK 25 to compile and run. Ensure your `JAVA_HOME` is set appropriately or your system's default Java is version 25.
+*   **Maven:** A modern version of Apache Maven.
+
+## Building the Executable JAR
+To create a standalone, executable "fat JAR" containing all required dependencies, run the following command in the project root directory:
+
+```bash
+mvn clean package
+```
+
+This uses the `maven-shade-plugin` to package everything into a single JAR file located in the `target/` directory.
+
+## Running the Application
+Once the build has completed successfully, you can launch the application using standard Java commands.
+
+Since JavaFX is modularized but bundled into a single shaded JAR in this setup, run it with the following command:
+
+```bash
+java --enable-preview -jar target/geantlr-0.1.0.jar
+```

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,38 @@
                     </options>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.geantlr.Launcher</mainClass>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/org/geantlr/Launcher.java
+++ b/src/main/java/org/geantlr/Launcher.java
@@ -1,0 +1,7 @@
+package org.geantlr;
+
+public class Launcher {
+    public static void main(String[] args) {
+        App.main(args);
+    }
+}


### PR DESCRIPTION
Configure Maven to build a standalone, executable JAR using the maven-shade-plugin. A Launcher wrapper class has been added to circumvent JavaFX module restrictions when executed from a fat JAR. A BUILDING.md file is included with instructions.

---
*PR created automatically by Jules for task [11720626263990521412](https://jules.google.com/task/11720626263990521412) started by @tkpixel*