### PR TITLE
feat: Domain-specific IntelliSense with PlantUML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
             <artifactId>jakarta.annotation-api</artifactId>
             <version>2.1.1</version>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.plantuml</groupId>
+            <artifactId>plantuml</artifactId>
+            <version>1.2024.3</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -23,6 +23,7 @@ module org.geantlr {
     requires langchain4j.ollama;
     requires google.genai;
     requires java.net.http;
+    requires net.sourceforge.plantuml;
 
     opens org.geantlr to javafx.fxml;
     opens org.geantlr.views to javafx.fxml;

--- a/src/main/java/org/geantlr/services/CodeCompletionService.java
+++ b/src/main/java/org/geantlr/services/CodeCompletionService.java
@@ -10,6 +10,7 @@ import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.runtime.Vocabulary;
 import org.antlr.v4.runtime.CommonTokenStream;
 
+import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -17,6 +18,13 @@ import java.util.Map;
 
 @Singleton
 public class CodeCompletionService {
+
+    private final PlantUmlParsingService plantUmlParsingService;
+
+    @Inject
+    public CodeCompletionService(PlantUmlParsingService plantUmlParsingService) {
+        this.plantUmlParsingService = plantUmlParsingService;
+    }
 
     public List<String> getSuggestedTokens(DynamicGrammar grammar, String text, int caretPosition) {
         if (grammar == null || text == null || grammar.getParserGrammar() == null) {
@@ -65,6 +73,26 @@ public class CodeCompletionService {
                 String displayName = vocabulary.getDisplayName(id);
                 if (displayName != null) {
                     suggestedTokens.add(displayName);
+                }
+            }
+        }
+
+        // Check context for dot accessor
+        if (tokenIndex > 1 && tokens.size() >= tokenIndex) {
+            Token previousToken = tokens.get(tokenIndex - 1);
+            if (".".equals(previousToken.getText())) {
+                Token objectToken = tokens.get(tokenIndex - 2);
+                String objectName = objectToken.getText();
+                Map<String, DomainClass> domainModelCache = plantUmlParsingService.getDomainModelCache();
+                if (domainModelCache.containsKey(objectName)) {
+                    DomainClass domainClass = domainModelCache.get(objectName);
+                    if (domainClass != null && domainClass.fields() != null) {
+                        for (String field : domainClass.fields()) {
+                            if (!suggestedTokens.contains(field)) {
+                                suggestedTokens.add(field);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/main/java/org/geantlr/services/CodeCompletionService.java
+++ b/src/main/java/org/geantlr/services/CodeCompletionService.java
@@ -78,14 +78,37 @@ public class CodeCompletionService {
         }
 
         // Check context for dot accessor
-        if (tokenIndex > 1 && tokens.size() >= tokenIndex) {
+        if (tokenIndex > 0 && tokens.size() >= tokenIndex) {
             Token previousToken = tokens.get(tokenIndex - 1);
-            if (".".equals(previousToken.getText())) {
-                Token objectToken = tokens.get(tokenIndex - 2);
-                String objectName = objectToken.getText();
+            String objectName = null;
+
+            if (".".equals(previousToken.getText()) && tokenIndex >= 2) {
+                objectName = tokens.get(tokenIndex - 2).getText();
+            } else if (tokenIndex >= 3 && ".".equals(tokens.get(tokenIndex - 2).getText())) {
+                objectName = tokens.get(tokenIndex - 3).getText();
+            }
+
+            if (objectName != null) {
                 Map<String, DomainClass> domainModelCache = plantUmlParsingService.getDomainModelCache();
-                if (domainModelCache.containsKey(objectName)) {
-                    DomainClass domainClass = domainModelCache.get(objectName);
+
+                // Try to resolve the variable name to its type by looking backwards in the token stream
+                // for a pattern like "Type objectName" or "Type objectName,"
+                String resolvedType = objectName;
+                if (!domainModelCache.containsKey(objectName)) {
+                    for (int i = tokenIndex - 1; i >= 1; i--) {
+                        if (objectName.equals(tokens.get(i).getText())) {
+                            // The token before the objectName might be its type
+                            String possibleType = tokens.get(i - 1).getText();
+                            if (domainModelCache.containsKey(possibleType)) {
+                                resolvedType = possibleType;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                if (domainModelCache.containsKey(resolvedType)) {
+                    DomainClass domainClass = domainModelCache.get(resolvedType);
                     if (domainClass != null && domainClass.fields() != null) {
                         for (String field : domainClass.fields()) {
                             if (!suggestedTokens.contains(field)) {

--- a/src/main/java/org/geantlr/services/CodeCompletionService.java
+++ b/src/main/java/org/geantlr/services/CodeCompletionService.java
@@ -6,7 +6,6 @@ import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.LexerInterpreter;
 import org.antlr.v4.runtime.Token;
-import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.runtime.Vocabulary;
 import org.antlr.v4.runtime.CommonTokenStream;
 
@@ -15,11 +14,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Singleton
 public class CodeCompletionService {
 
     private final PlantUmlParsingService plantUmlParsingService;
+
+    // Pattern to find variable declarations like "ClassName varName" or "ClassName varName,"
+    private static final Pattern VAR_DECL_PATTERN = Pattern.compile(
+        "([A-Z][a-zA-Z0-9_]*)\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*[,;=)\\n\\r]|$)"
+    );
 
     @Inject
     public CodeCompletionService(PlantUmlParsingService plantUmlParsingService) {
@@ -27,7 +33,19 @@ public class CodeCompletionService {
     }
 
     public List<String> getSuggestedTokens(DynamicGrammar grammar, String text, int caretPosition) {
-        if (grammar == null || text == null || grammar.getParserGrammar() == null) {
+        if (text == null) return Collections.emptyList();
+
+        List<String> suggestedTokens = new ArrayList<>();
+
+        // --- Domain model dot-accessor suggestions (text-based, grammar-independent) ---
+        List<String> domainSuggestions = getDomainMemberSuggestions(text, caretPosition);
+        if (!domainSuggestions.isEmpty()) {
+            // When we are after a dot, only show domain-model members (no grammar tokens)
+            return domainSuggestions;
+        }
+
+        // --- Grammar-based token suggestions ---
+        if (grammar == null || grammar.getParserGrammar() == null) {
             return Collections.emptyList();
         }
 
@@ -61,9 +79,7 @@ public class CodeCompletionService {
         CodeCompletionCore core = new CodeCompletionCore(grammar.getParserGrammar().createParserInterpreter(tokenStream), null, null);
         CodeCompletionCore.CandidatesCollection candidates = core.collectCandidates(tokenIndex, null);
 
-        List<String> suggestedTokens = new ArrayList<>();
         Vocabulary vocabulary = grammar.getVocabulary();
-
         if (vocabulary == null && grammar.getParserGrammar() != null) {
             vocabulary = grammar.getParserGrammar().getVocabulary();
         }
@@ -77,49 +93,104 @@ public class CodeCompletionService {
             }
         }
 
-        // Check context for dot accessor
-        if (tokenIndex > 0 && tokens.size() >= tokenIndex) {
-            Token previousToken = tokens.get(tokenIndex - 1);
-            String objectName = null;
+        return suggestedTokens;
+    }
 
-            if (".".equals(previousToken.getText()) && tokenIndex >= 2) {
-                objectName = tokens.get(tokenIndex - 2).getText();
-            } else if (tokenIndex >= 3 && ".".equals(tokens.get(tokenIndex - 2).getText())) {
-                objectName = tokens.get(tokenIndex - 3).getText();
-            }
-
-            if (objectName != null) {
-                Map<String, DomainClass> domainModelCache = plantUmlParsingService.getDomainModelCache();
-
-                // Try to resolve the variable name to its type by looking backwards in the token stream
-                // for a pattern like "Type objectName" or "Type objectName,"
-                String resolvedType = objectName;
-                if (!domainModelCache.containsKey(objectName)) {
-                    for (int i = tokenIndex - 1; i >= 1; i--) {
-                        if (objectName.equals(tokens.get(i).getText())) {
-                            // The token before the objectName might be its type
-                            String possibleType = tokens.get(i - 1).getText();
-                            if (domainModelCache.containsKey(possibleType)) {
-                                resolvedType = possibleType;
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if (domainModelCache.containsKey(resolvedType)) {
-                    DomainClass domainClass = domainModelCache.get(resolvedType);
-                    if (domainClass != null && domainClass.fields() != null) {
-                        for (String field : domainClass.fields()) {
-                            if (!suggestedTokens.contains(field)) {
-                                suggestedTokens.add(field);
-                            }
-                        }
-                    }
-                }
-            }
+    /**
+     * Determines if the cursor is positioned after a dot accessor and returns the
+     * members of the resolved type. Supports chained access like ctx.datenpunkt.
+     *
+     * Examples:
+     *   "ctx."            → resolves ctx → DatenpunktKontext → fields of DatenpunktKontext
+     *   "ctx.datenpunkt." → resolves ctx → DatenpunktKontext, then datenpunkt → Datenpunkt → fields of Datenpunkt
+     *   "ctx.datenpunkt.bal" → same as above (partial match after last dot is ignored for type resolution)
+     */
+    private List<String> getDomainMemberSuggestions(String text, int caretPosition) {
+        Map<String, DomainClass> cache = plantUmlParsingService.getDomainModelCache();
+        if (cache == null || cache.isEmpty()) {
+            return Collections.emptyList();
         }
 
-        return suggestedTokens;
+        int safeEnd = Math.min(caretPosition, text.length());
+        String textBeforeCaret = text.substring(0, safeEnd);
+
+        // Extract the dot-chain immediately before the caret.
+        // We walk backwards from the caret, collecting identifier.identifier. segments.
+        // Stop at any character that cannot be part of an identifier or dot (whitespace, operators, etc.)
+        int end = textBeforeCaret.length() - 1;
+        // Skip trailing partial identifier after last dot (e.g. "ctx.datenpunkt.bal" → ignore "bal")
+        while (end >= 0 && (Character.isLetterOrDigit(textBeforeCaret.charAt(end)) || textBeforeCaret.charAt(end) == '_')) {
+            end--;
+        }
+        // There must be a dot right here
+        if (end < 0 || textBeforeCaret.charAt(end) != '.') {
+            return Collections.emptyList();
+        }
+        // Now collect the full chain before the dot
+        int chainEnd = end; // exclusive – points at the dot
+        int chainStart = chainEnd - 1;
+        while (chainStart >= 0) {
+            char c = textBeforeCaret.charAt(chainStart);
+            if (Character.isLetterOrDigit(c) || c == '_' || c == '.') {
+                chainStart--;
+            } else {
+                break;
+            }
+        }
+        chainStart++; // first char of the chain
+
+        if (chainStart >= chainEnd) {
+            return Collections.emptyList();
+        }
+
+        String chain = textBeforeCaret.substring(chainStart, chainEnd); // e.g. "ctx" or "ctx.datenpunkt"
+        String[] segments = chain.split("\\.");
+
+        // Resolve first segment: it may be a variable name or a class name directly
+        String currentType = resolveVariableType(segments[0], text, cache);
+        if (currentType == null) {
+            return Collections.emptyList();
+        }
+
+        // Walk remaining segments using fieldTypes
+        for (int i = 1; i < segments.length; i++) {
+            DomainClass currentClass = cache.get(currentType);
+            if (currentClass == null) return Collections.emptyList();
+
+            String fieldName = segments[i];
+            String nextType = currentClass.fieldTypes().get(fieldName);
+            if (nextType == null) {
+                // Field exists but type unknown – cannot go deeper
+                return Collections.emptyList();
+            }
+            currentType = nextType;
+        }
+
+        DomainClass target = cache.get(currentType);
+        if (target == null || target.fields() == null) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(target.fields());
+    }
+
+    /**
+     * Resolves a variable/identifier name to a domain class name.
+     * Checks (in order):
+     *  1. Is the name itself a known class? → return it
+     *  2. Scan text for "ClassName varName" declarations
+     */
+    private String resolveVariableType(String variableName, String fullText, Map<String, DomainClass> cache) {
+        if (cache.containsKey(variableName)) {
+            return variableName;
+        }
+        Matcher varDecl = VAR_DECL_PATTERN.matcher(fullText);
+        while (varDecl.find()) {
+            String typeName = varDecl.group(1);
+            String varName  = varDecl.group(2);
+            if (varName.equals(variableName) && cache.containsKey(typeName)) {
+                return typeName;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/geantlr/services/DomainClass.java
+++ b/src/main/java/org/geantlr/services/DomainClass.java
@@ -1,0 +1,5 @@
+package org.geantlr.services;
+
+import java.util.List;
+
+public record DomainClass(String name, List<String> fields) {}

--- a/src/main/java/org/geantlr/services/DomainClass.java
+++ b/src/main/java/org/geantlr/services/DomainClass.java
@@ -1,5 +1,20 @@
 package org.geantlr.services;
 
 import java.util.List;
+import java.util.Map;
 
-public record DomainClass(String name, List<String> fields) {}
+/**
+ * Represents a domain class parsed from a PlantUML diagram.
+ *
+ * @param name       the class name
+ * @param fields     list of field/method names (for auto-complete display)
+ * @param fieldTypes map of field name → declared type name (e.g. "datenpunkt" → "Datenpunkt"),
+ *                   used to resolve chained dot-accessor expressions like ctx.datenpunkt.
+ */
+public record DomainClass(String name, List<String> fields, Map<String, String> fieldTypes) {
+
+    /** Convenience constructor for classes without type information (backwards compat). */
+    public DomainClass(String name, List<String> fields) {
+        this(name, fields, new java.util.HashMap<>());
+    }
+}

--- a/src/main/java/org/geantlr/services/PlantUmlParsingService.java
+++ b/src/main/java/org/geantlr/services/PlantUmlParsingService.java
@@ -1,0 +1,54 @@
+package org.geantlr.services;
+
+import jakarta.inject.Singleton;
+import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.classdiagram.ClassDiagram;
+import net.sourceforge.plantuml.abel.Entity;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+public class PlantUmlParsingService {
+
+    private final Map<String, DomainClass> domainModelCache = new HashMap<>();
+
+    public void parseDomainModel(String pumlContent) {
+        domainModelCache.clear();
+        try {
+            SourceStringReader reader = new SourceStringReader(pumlContent);
+            if (reader.getBlocks().isEmpty()) {
+                return;
+            }
+
+            var diagram = reader.getBlocks().get(0).getDiagram();
+            if (diagram instanceof ClassDiagram cd) {
+                var classes = cd.getEntityFactory().root().getChildren();
+
+                for (var node : classes) {
+                    String className = node.getName();
+                    List<String> fields = new ArrayList<>();
+                    var data = node.getData();
+
+                    if (data instanceof Entity entity) {
+                        for (CharSequence member : entity.getBodier().getFieldsToDisplay()) {
+                            fields.add(member.toString());
+                        }
+                        for (CharSequence member : entity.getBodier().getMethodsToDisplay()) {
+                            fields.add(member.toString());
+                        }
+                        domainModelCache.put(className, new DomainClass(className, fields));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public Map<String, DomainClass> getDomainModelCache() {
+        return domainModelCache;
+    }
+}

--- a/src/main/java/org/geantlr/services/PlantUmlParsingService.java
+++ b/src/main/java/org/geantlr/services/PlantUmlParsingService.java
@@ -10,48 +10,426 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Singleton
 public class PlantUmlParsingService {
 
     private final Map<String, DomainClass> domainModelCache = new HashMap<>();
 
+    // Matches: (class|abstract class|interface|enum) ClassName { ... }
+    // Body is everything between { and either } or the next class/interface/enum/abstract keyword
+    private static final Pattern CLASS_PATTERN = Pattern.compile(
+        "(?:abstract\\s+class|class|interface|enum)\\s+(\\w+)(?:\\s+extends\\s+\\w+)?(?:\\s+implements\\s+\\w+)?\\s*\\{([^}]*)"
+    );
+    // Matches a field/method name in the form: [visibility] name : Type  or  [Type] name
+    private static final Pattern FIELD_PATTERN = Pattern.compile(
+        "(?:[+\\-#~]\\s*)?(\\w+)\\s*(?::\\s*\\S+|\\()"
+    );
+    // Pattern to strip note blocks before parsing
+    private static final Pattern NOTE_PATTERN = Pattern.compile(
+        "note\\s+(?:top|bottom|left|right)(?:\\s+of\\s+\\w+)?.*?end\\s+note",
+        Pattern.DOTALL
+    );
+
+    private static final java.util.Set<String> COLLECTION_TYPES = java.util.Set.of(
+        "List", "Set", "Collection", "Map", "Iterable", "ArrayList", "LinkedList", "HashSet"
+    );
+
     public void parseDomainModel(String pumlContent) {
         domainModelCache.clear();
+        if (pumlContent == null || pumlContent.isBlank()) return;
+
+        // First attempt: use PlantUML library
         try {
             SourceStringReader reader = new SourceStringReader(pumlContent);
-            if (reader.getBlocks().isEmpty()) {
-                return;
-            }
+            if (!reader.getBlocks().isEmpty()) {
+                var diagram = reader.getBlocks().get(0).getDiagram();
+                if (diagram instanceof ClassDiagram cd) {
+                    var classes = cd.getEntityFactory().root().getChildren();
 
-            var diagram = reader.getBlocks().get(0).getDiagram();
-            if (diagram instanceof ClassDiagram cd) {
-                var classes = cd.getEntityFactory().root().getChildren();
+                    for (var node : classes) {
+                        String className = node.getName();
+                        List<String> fields = new ArrayList<>();
+                        var data = node.getData();
 
-                for (var node : classes) {
-                    String className = node.getName();
-                    List<String> fields = new ArrayList<>();
-                    var data = node.getData();
-
-                    if (data instanceof Entity entity) {
-                        LeafType type = entity.getLeafType();
-                        if (type == LeafType.CLASS || type == LeafType.ENUM || type == LeafType.INTERFACE || type == LeafType.ABSTRACT_CLASS) {
-                            for (CharSequence member : entity.getBodier().getFieldsToDisplay()) {
-                                String clean = cleanMember(member.toString());
-                                if (!clean.isEmpty()) fields.add(clean);
+                        if (data instanceof Entity entity) {
+                            LeafType type = entity.getLeafType();
+                            if (type == LeafType.CLASS || type == LeafType.ENUM || type == LeafType.INTERFACE || type == LeafType.ABSTRACT_CLASS) {
+                                Map<String, String> fieldTypes = new HashMap<>();
+                                for (CharSequence member : entity.getBodier().getFieldsToDisplay()) {
+                                    String raw = member.toString();
+                                    String clean = cleanMember(raw);
+                                    if (!clean.isEmpty()) {
+                                        fields.add(clean);
+                                        extractFieldType(raw, clean, fieldTypes);
+                                    }
+                                }
+                                for (CharSequence member : entity.getBodier().getMethodsToDisplay()) {
+                                    String clean = cleanMember(member.toString());
+                                    if (!clean.isEmpty()) fields.add(clean);
+                                }
+                                domainModelCache.put(className, new DomainClass(className, fields, fieldTypes));
                             }
-                            for (CharSequence member : entity.getBodier().getMethodsToDisplay()) {
-                                String clean = cleanMember(member.toString());
-                                if (!clean.isEmpty()) fields.add(clean);
-                            }
-                            domainModelCache.put(className, new DomainClass(className, fields));
                         }
                     }
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            System.err.println("[PlantUmlParsingService] PlantUML library parsing failed: " + e.getMessage());
         }
+
+        // Fallback / supplement: regex-based parsing to catch classes the library may have missed
+        // (e.g. unclosed braces, single-line format)
+        parseDomainModelViaRegex(pumlContent);
+
+        // Third pass: derive fields from UML relations (e.g. "A *-- B" → A gets field b: B)
+        parseDomainModelViaRelations(pumlContent);
+
+        // Fourth pass: add implicit "wert" field to classes that appear to be value wrappers
+        // (i.e. their name contains "Wert"/"Wert"/"Value" and they still have no "wert" field)
+        addImplicitWertFields();
+
+        // Fifth pass: remove spurious fields that are class names but were never added
+        // via an explicit relation (they ended up as fields due to incomplete PUML parsing
+        // by the PlantUML library, e.g. when braces are missing).
+        removeSpuriousClassNameFields();
+
+        // Diagnostics – printed to stdout so the developer can verify the parsed model
+        System.out.println("[PlantUmlParsingService] Parsed " + domainModelCache.size() + " classes:");
+        domainModelCache.forEach((name, dc) ->
+            System.out.println("  " + name + " → fields: " + dc.fields() + " | types: " + dc.fieldTypes())
+        );
+    }
+
+    /**
+     * Removes fields whose name (as camelCase class name) is a known domain class
+     * but that were NOT added through an explicit relation (i.e. not present in fieldTypes).
+     * This cleans up artefacts from incomplete PlantUML parsing where class names leak
+     * into field lists (e.g. "DatenpunktKontextSammlung" appearing as a field on DatenpunktKontext).
+     */
+    private void removeSpuriousClassNameFields() {
+        for (DomainClass dc : domainModelCache.values()) {
+            dc.fields().removeIf(field -> {
+                // A field is spurious if:
+                // 1. Its PascalCase form is a known class name (e.g. field "datenpunktKontextSammlung"
+                //    → class "DatenpunktKontextSammlung")
+                // 2. It is NOT registered in fieldTypes (i.e. was not added by an explicit relation
+                //    or body field with a declared type pointing to that class)
+                if (field == null || field.isEmpty()) return false;
+                String pascalCase = Character.toUpperCase(field.charAt(0)) + field.substring(1);
+                boolean isKnownClass = domainModelCache.containsKey(pascalCase)
+                    || domainModelCache.containsKey(field); // exact match (already PascalCase)
+                boolean hasExplicitType = dc.fieldTypes().containsKey(field);
+                return isKnownClass && !hasExplicitType;
+            });
+        }
+    }
+
+    /**
+     * For every class whose name suggests it is a value-with-source wrapper
+     * (name contains "Wert", "Value", or "Quelle") and that does not yet have a "wert" field,
+     * we add an implicit "wert" field so that "someField.wert" chains resolve correctly.
+     */
+    private void addImplicitWertFields() {
+        for (DomainClass dc : domainModelCache.values()) {
+            String name = dc.name();
+            boolean isWertWrapper = name.contains("Wert") || name.contains("Value") || name.contains("wert");
+            if (isWertWrapper && !dc.fields().contains("wert")) {
+                dc.fields().add("wert");
+                // "wert" has no specific domain class type, leave out of fieldTypes
+                // so it doesn't try to drill down further
+            }
+        }
+    }
+
+    /**
+     * Parses UML relation lines and adds the target class as a field on the source class.
+     *
+     * Direction rules:
+     *   A *-- B   →  A owns B  →  A gets field of type B  (composition, A is parent)
+     *   A o-- B   →  A owns B  →  A gets field of type B  (aggregation)
+     *   A --> B   →  A→B       →  A gets field of type B  (directed association)
+     *   A -- B    →  undirected →  both get a field (pure association, no ownership)
+     *   A --|> B  →  inheritance → IGNORED (no field added)
+     *   A -up-|> B → inheritance → IGNORED
+     *
+     * The field name is derived from the target class name in camelCase.
+     * Only adds the field if not already explicitly declared.
+     */
+    private void parseDomainModelViaRelations(String pumlContent) {
+        String withoutNotes = NOTE_PATTERN.matcher(pumlContent).replaceAll(" ");
+
+        // Match lines of the form:
+        //   Word [mult] <arrow> [mult] Word
+        // Capture groups: 1=left class, 2=arrow, 3=right class
+        Pattern relationPattern = Pattern.compile(
+            "^\\s*(\\w+)\\s*(?:\"[^\"]*\"\\s*)?([-.<>|o*]{2,})(?:\\s*\"[^\"]*\")?\\s+(\\w+)\\s*$",
+            Pattern.MULTILINE
+        );
+
+        Matcher m = relationPattern.matcher(withoutNotes);
+        while (m.find()) {
+            String left  = m.group(1);
+            String arrow = m.group(2);
+            String right = m.group(3);
+
+            if (left.equals(right)) continue;
+
+            if (arrow.contains("|>") || arrow.contains("|<") || arrow.contains("<|") || arrow.contains(">|")) {
+                continue;
+            }
+
+            boolean isComposition  = arrow.contains("*");
+            boolean isAggregation  = arrow.contains("o");
+            boolean hasRightArrow  = arrow.endsWith(">");
+            boolean hasLeftArrow   = arrow.startsWith("<");
+            boolean isUndirected   = !isComposition && !isAggregation && !hasRightArrow && !hasLeftArrow;
+
+            boolean leftOwnsRight  = isComposition && !arrow.startsWith("--*")
+                                   || isAggregation && !arrow.startsWith("--o")
+                                   || hasRightArrow
+                                   || isUndirected;
+
+            boolean rightOwnsLeft  = isComposition && arrow.startsWith("--*")
+                                   || isAggregation && arrow.startsWith("--o")
+                                   || hasLeftArrow;
+
+            // Ensure both ends exist as cache stubs BEFORE trying to add fields,
+            // so tryAddRelationField finds both sides even if not declared as classes.
+            ensureCacheEntry(left);
+            ensureCacheEntry(right);
+
+            if (leftOwnsRight)  tryAddRelationField(left,  right);
+            if (rightOwnsLeft)  tryAddRelationField(right, left);
+        }
+    }
+
+    private void ensureCacheEntry(String className) {
+        if (!domainModelCache.containsKey(className)) {
+            domainModelCache.put(className, new DomainClass(className, new ArrayList<>(), new HashMap<>()));
+        }
+    }
+
+    /**
+     * Adds a field named after targetClass (camelCase) to ownerClass if:
+     * - ownerClass exists in the cache
+     * - targetClass exists in the cache
+     * - the field is not already present
+     *
+     * Also adds a shortened variant by stripping common suffixes
+     * (Ref, DTO, VO, Entity, Model) so that e.g. "QuellenRef" produces
+     * both "quellenRef" and "quelle" as candidate field names.
+     */
+    private void tryAddRelationField(String ownerClassName, String targetClassName) {
+        DomainClass owner  = domainModelCache.get(ownerClassName);
+        DomainClass target = domainModelCache.get(targetClassName);
+        if (owner == null || target == null) return;
+
+        // Check if any existing field already points to this target type → skip entirely
+        if (owner.fieldTypes().containsValue(targetClassName)) return;
+
+        // Check if any existing field has a raw collection type (List/Set/etc.) with no domain
+        // type – this means the field was declared as e.g. "DatenpunktKontexte: List" and the
+        // relation tells us the element type is targetClassName. Upgrade that field's type.
+        for (String existingField : owner.fields()) {
+            String existingType = owner.fieldTypes().get(existingField);
+            if (existingType != null && COLLECTION_TYPES.contains(existingType)) {
+                owner.fieldTypes().put(existingField, targetClassName);
+                return; // type upgraded – no new field needed
+            }
+        }
+
+        // No existing field covers this relation – add a camelCase field for it
+        String fullFieldName = Character.toLowerCase(targetClassName.charAt(0)) + targetClassName.substring(1);
+        addFieldIfAbsent(owner, fullFieldName, targetClassName);
+
+        // Also add shortened variant (e.g. QuellenRef → quelle)
+        String shortened = stripClassNameSuffix(targetClassName);
+        if (!shortened.equals(targetClassName)) {
+            String shortFieldName = Character.toLowerCase(shortened.charAt(0)) + shortened.substring(1);
+            if (!shortFieldName.equals(fullFieldName)) {
+                addFieldIfAbsent(owner, shortFieldName, targetClassName);
+            }
+        }
+    }
+
+    private void addFieldIfAbsent(DomainClass owner, String fieldName, String targetClassName) {
+        if (!owner.fields().contains(fieldName)) {
+            owner.fields().add(fieldName);
+            owner.fieldTypes().put(fieldName, targetClassName);
+        }
+    }
+
+    /** Strips common OOP suffix patterns: Ref, DTO, VO, Entity, Model, Service, Type */
+    private String stripClassNameSuffix(String className) {
+        for (String suffix : new String[]{"Ref", "DTO", "Dto", "VO", "Vo", "Entity", "Model", "Service", "Type", "Info"}) {
+            if (className.endsWith(suffix) && className.length() > suffix.length()) {
+                return className.substring(0, className.length() - suffix.length());
+            }
+        }
+        return className;
+    }
+
+    /**
+     * Regex-based fallback parser that can handle single-line PlantUML class definitions
+     * and definitions with unclosed braces.
+     */
+    private void parseDomainModelViaRegex(String pumlContent) {
+        // Remove note blocks first (they contain free text that may confuse field parsing)
+        String withoutNotes = NOTE_PATTERN.matcher(pumlContent).replaceAll(" ");
+
+        // Normalize: replace multiple whitespace/newlines with single space for simpler matching
+        String normalized = withoutNotes.replaceAll("\\r?\\n", " ").replaceAll("\\s{2,}", " ");
+
+        Matcher classMatcher = CLASS_PATTERN.matcher(normalized);
+        while (classMatcher.find()) {
+            String className = classMatcher.group(1);
+            String rawBody = classMatcher.group(2).trim();
+
+            // If the body wasn't closed by "}", truncate at the next class/enum/interface/abstract keyword
+            // so we don't accidentally include the content of following classes
+            Pattern nextClassKeyword = Pattern.compile(
+                "\\b(?:abstract\\s+class|class|interface|enum|rectangle|@enduml)\\b"
+            );
+            Matcher nextKw = nextClassKeyword.matcher(rawBody);
+            String body = nextKw.find() ? rawBody.substring(0, nextKw.start()).trim() : rawBody;
+
+            if (domainModelCache.containsKey(className) && !domainModelCache.get(className).fields().isEmpty()) {
+                // Already parsed by PlantUML library with fields – skip
+                continue;
+            }
+
+            List<String> fields = new ArrayList<>();
+            Map<String, String> fieldTypes = new HashMap<>();
+
+            // Split body by whitespace-boundaries between field declarations
+            // Fields look like: "name: Type" or "+name: Type" or "name()"
+            // We split on spaces and try to identify field/method names
+            String[] parts = body.split("\\s+");
+            for (int i = 0; i < parts.length; i++) {
+                String part = parts[i];
+                // Skip visibility markers standalone, keywords, and type annotations
+                if (part.matches("[+\\-#~]")) continue;
+                // Strip leading visibility char if attached
+                String cleaned = part.replaceAll("^[+\\-#~]", "");
+                if (cleaned.isEmpty()) continue;
+
+                // If this part ends with ":" it is "fieldName:" pattern
+                if (cleaned.endsWith(":")) {
+                    String rawName = cleaned.substring(0, cleaned.length() - 1).trim();
+                    // Always start field names with lower-case (e.g. DatenpunktKontexte → datenpunktKontexte)
+                    String fieldName = Character.toLowerCase(rawName.charAt(0)) + rawName.substring(1);
+                    if (isValidIdentifier(fieldName) && !fields.contains(fieldName)) {
+                        fields.add(fieldName);
+                        if (i + 1 < parts.length) {
+                            String typeName = stripGeneric(parts[i + 1]);
+                            if (isValidIdentifier(typeName)) fieldTypes.put(fieldName, typeName);
+                            i++;
+                        }
+                        continue;
+                    }
+                }
+
+                // If the next part is ":" (separate token), this part is the field name
+                if (i + 1 < parts.length && parts[i + 1].equals(":")) {
+                    String rawName = cleaned.trim();
+                    // Always start field names with lower-case
+                    String fieldName = Character.toLowerCase(rawName.charAt(0)) + rawName.substring(1);
+                    if (isValidIdentifier(fieldName) && !fields.contains(fieldName)) {
+                        fields.add(fieldName);
+                        if (i + 2 < parts.length) {
+                            String typeName = stripGeneric(parts[i + 2]);
+                            if (isValidIdentifier(typeName)) fieldTypes.put(fieldName, typeName);
+                            i += 2;
+                        } else {
+                            i += 1;
+                        }
+                        continue;
+                    }
+                }
+
+                // Method name: ends with "()" or similar
+                if (cleaned.endsWith("()") || cleaned.endsWith("(")) {
+                    String methodName = cleaned.replaceAll("\\(.*", "");
+                    if (isValidIdentifier(methodName) && !fields.contains(methodName)) {
+                        fields.add(methodName);
+                    }
+                }
+            }
+
+            DomainClass existing = domainModelCache.get(className);
+            if (existing == null || existing.fields().isEmpty()) {
+                // Library parsed nothing or an empty body – use regex result
+                domainModelCache.put(className, new DomainClass(className, fields, fieldTypes));
+            } else if (!fields.isEmpty()) {
+                // Both have fields – supplement missing ones (regex may catch things library missed)
+                for (int fi = 0; fi < fields.size(); fi++) {
+                    String f = fields.get(fi);
+                    if (!existing.fields().contains(f)) {
+                        existing.fields().add(f);
+                        String t = fieldTypes.get(f);
+                        if (t != null) existing.fieldTypes().put(f, t);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isValidIdentifier(String s) {
+        if (s == null || s.isEmpty()) return false;
+        return s.matches("[a-zA-Z_][a-zA-Z0-9_]*");
+    }
+
+    /**
+     * Extracts the declared type from a raw PlantUML member string like
+     * "datenpunkt: Datenpunkt" or "+bezugspunkt : Bezugspunkt" and stores it in fieldTypes.
+     */
+    private void extractFieldType(String rawMember, String fieldName, Map<String, String> fieldTypes) {
+        if (rawMember == null || fieldName == null) return;
+        int colonIdx = rawMember.lastIndexOf(':');
+        if (colonIdx == -1) return;
+        String typePart = rawMember.substring(colonIdx + 1).trim();
+        // Strip generic brackets e.g. "List<Balise>" → "Balise", "List" stays if no <
+        String typeName = stripGeneric(typePart);
+        if (isValidIdentifier(typeName)) {
+            fieldTypes.put(fieldName, typeName);
+        }
+    }
+
+    /**
+     * Resolves the navigable type from a PlantUML type string.
+     *
+     * Rules:
+     *  - "WertMitQuelle&lt;String&gt;"  → "WertMitQuelle"  (domain wrapper, keep outer type)
+     *  - "List&lt;Balise&gt;"           → "Balise"          (pure collection, extract element type)
+     *  - "WertMitQuelle"               → "WertMitQuelle"
+     *  - "String"                      → "String"
+     */
+    private String stripGeneric(String typeName) {
+        if (typeName == null) return "";
+        typeName = typeName.trim().replaceAll("[;,]$", "");
+
+        int open = typeName.indexOf('<');
+        if (open == -1) return typeName;
+
+        String outerType = typeName.substring(0, open).trim();
+
+        // Only unwrap generic parameter for pure collection types (List<Balise> → Balise).
+        // For domain types like WertMitQuelle<String> the outer type IS the field type.
+        if (COLLECTION_TYPES.contains(outerType)) {
+            int close = typeName.lastIndexOf('>');
+            if (close > open) {
+                String inner = typeName.substring(open + 1, close).trim();
+                // Map<K,V> → take value type
+                int comma = inner.indexOf(',');
+                if (comma != -1) inner = inner.substring(comma + 1).trim();
+                return inner;
+            }
+        }
+
+        return outerType;
     }
 
     public Map<String, DomainClass> getDomainModelCache() {
@@ -63,7 +441,7 @@ public class PlantUmlParsingService {
             return "";
         }
         String clean = memberStr.replaceAll("^[+\\-#~\\s]+", "");
-        clean = clean.replaceAll("\\{.*?\\}\\s*", "");
+        clean = clean.replaceAll("\\{.*?}\\s*", "");
 
         if (clean.contains("(")) {
             int openParenIndex = clean.indexOf("(");

--- a/src/main/java/org/geantlr/services/PlantUmlParsingService.java
+++ b/src/main/java/org/geantlr/services/PlantUmlParsingService.java
@@ -4,6 +4,7 @@ import jakarta.inject.Singleton;
 import net.sourceforge.plantuml.SourceStringReader;
 import net.sourceforge.plantuml.classdiagram.ClassDiagram;
 import net.sourceforge.plantuml.abel.Entity;
+import net.sourceforge.plantuml.abel.LeafType;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,13 +34,16 @@ public class PlantUmlParsingService {
                     var data = node.getData();
 
                     if (data instanceof Entity entity) {
-                        for (CharSequence member : entity.getBodier().getFieldsToDisplay()) {
-                            fields.add(member.toString());
+                        LeafType type = entity.getLeafType();
+                        if (type == LeafType.CLASS || type == LeafType.ENUM || type == LeafType.INTERFACE || type == LeafType.ABSTRACT_CLASS) {
+                            for (CharSequence member : entity.getBodier().getFieldsToDisplay()) {
+                                fields.add(member.toString());
+                            }
+                            for (CharSequence member : entity.getBodier().getMethodsToDisplay()) {
+                                fields.add(member.toString());
+                            }
+                            domainModelCache.put(className, new DomainClass(className, fields));
                         }
-                        for (CharSequence member : entity.getBodier().getMethodsToDisplay()) {
-                            fields.add(member.toString());
-                        }
-                        domainModelCache.put(className, new DomainClass(className, fields));
                     }
                 }
             }

--- a/src/main/java/org/geantlr/services/PlantUmlParsingService.java
+++ b/src/main/java/org/geantlr/services/PlantUmlParsingService.java
@@ -37,10 +37,12 @@ public class PlantUmlParsingService {
                         LeafType type = entity.getLeafType();
                         if (type == LeafType.CLASS || type == LeafType.ENUM || type == LeafType.INTERFACE || type == LeafType.ABSTRACT_CLASS) {
                             for (CharSequence member : entity.getBodier().getFieldsToDisplay()) {
-                                fields.add(member.toString());
+                                String clean = cleanMember(member.toString());
+                                if (!clean.isEmpty()) fields.add(clean);
                             }
                             for (CharSequence member : entity.getBodier().getMethodsToDisplay()) {
-                                fields.add(member.toString());
+                                String clean = cleanMember(member.toString());
+                                if (!clean.isEmpty()) fields.add(clean);
                             }
                             domainModelCache.put(className, new DomainClass(className, fields));
                         }
@@ -54,5 +56,59 @@ public class PlantUmlParsingService {
 
     public Map<String, DomainClass> getDomainModelCache() {
         return domainModelCache;
+    }
+
+    private String cleanMember(String memberStr) {
+        if (memberStr == null || memberStr.isBlank()) {
+            return "";
+        }
+        String clean = memberStr.replaceAll("^[+\\-#~\\s]+", "");
+        clean = clean.replaceAll("\\{.*?\\}\\s*", "");
+
+        if (clean.contains("(")) {
+            int openParenIndex = clean.indexOf("(");
+            String beforeParen = clean.substring(0, openParenIndex).trim();
+
+            int splitIdx = -1;
+            for (int i = beforeParen.length() - 1; i >= 0; i--) {
+                char c = beforeParen.charAt(i);
+                if (c == ' ' || c == '>') {
+                    splitIdx = i;
+                    break;
+                }
+            }
+
+            String methodName;
+            if (splitIdx != -1 && splitIdx < beforeParen.length() - 1) {
+                methodName = beforeParen.substring(splitIdx + 1).trim();
+            } else {
+                methodName = beforeParen;
+            }
+
+            clean = methodName + clean.substring(openParenIndex);
+
+            int colonIndex = clean.lastIndexOf(":");
+            int closeParenIndex = clean.lastIndexOf(")");
+
+            if (colonIndex > closeParenIndex) {
+                clean = clean.substring(0, colonIndex).trim();
+            }
+        } else if (clean.contains(":")) {
+             clean = clean.substring(0, clean.indexOf(":")).trim();
+        } else {
+             int splitIdx = -1;
+             for (int i = clean.length() - 1; i >= 0; i--) {
+                char c = clean.charAt(i);
+                if (c == ' ' || c == '>') {
+                    splitIdx = i;
+                    break;
+                }
+            }
+             if (splitIdx != -1 && splitIdx < clean.length() - 1) {
+                 clean = clean.substring(splitIdx + 1).trim();
+             }
+        }
+
+        return clean.trim();
     }
 }

--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -76,7 +76,10 @@ public class EditorViewModel {
 
         textContent.addListener((obs, oldVal, newVal) -> {
             debounce.playFromStart();
-            updateSuggestions();
+            // Suggestions are updated via onCaretPositionChanged which fires after every keystroke.
+            // Calling updateSuggestions() here would use a stale caretPosition (before the new char
+            // was inserted), causing dot-accessor detection to fail. The caretPositionProperty
+            // listener in EditorViewController fires after the model change with the correct position.
         });
 
         loadAvailableOllamaModels();
@@ -279,12 +282,10 @@ public class EditorViewModel {
 
     private void updateSuggestions() {
         var grammar = mainViewModel.getDynamicGrammar();
-        if (grammar == null) {
-            Platform.runLater(suggestedTokens::clear);
-            return;
-        }
         String text = textContent.get();
         int caretPosition = this.currentCaretPosition;
+        // Pass grammar (may be null) – CodeCompletionService handles domain-model suggestions
+        // independently of the grammar, so suggestions are available even without a loaded grammar.
         CompletableFuture.supplyAsync(() -> codeCompletionService.getSuggestedTokens(grammar, text, caretPosition))
             .thenAccept(suggestions -> Platform.runLater(() -> suggestedTokens.setAll(suggestions)));
     }

--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -52,6 +52,7 @@ public class EditorViewModel {
     private final CodeFormattingService codeFormattingService;
     private final MainViewModel mainViewModel;
     private final org.geantlr.services.RuleGenerationService ruleGenerationService;
+    private final org.geantlr.services.PlantUmlParsingService plantUmlParsingService;
 
     public javafx.beans.property.BooleanProperty experimentalModeProperty() {
         return mainViewModel.experimentalModeProperty();
@@ -63,12 +64,13 @@ public class EditorViewModel {
     private final ObjectProperty<ReplaceTextCommand> replaceTextCommand = new SimpleObjectProperty<>();
 
     @Inject
-    public EditorViewModel(AntlrGrammarService antlrGrammarService, CodeCompletionService codeCompletionService, CodeFormattingService codeFormattingService, MainViewModel mainViewModel, org.geantlr.services.RuleGenerationService ruleGenerationService) {
+    public EditorViewModel(AntlrGrammarService antlrGrammarService, CodeCompletionService codeCompletionService, CodeFormattingService codeFormattingService, MainViewModel mainViewModel, org.geantlr.services.RuleGenerationService ruleGenerationService, org.geantlr.services.PlantUmlParsingService plantUmlParsingService) {
         this.antlrGrammarService = antlrGrammarService;
         this.codeCompletionService = codeCompletionService;
         this.codeFormattingService = codeFormattingService;
         this.mainViewModel = mainViewModel;
         this.ruleGenerationService = ruleGenerationService;
+        this.plantUmlParsingService = plantUmlParsingService;
 
         debounce.setOnFinished(event -> parseText(textContent.get()));
 
@@ -339,5 +341,16 @@ public class EditorViewModel {
         });
 
         new Thread(generationTask).start();
+    }
+
+    public void loadDomainModel(java.io.File file) {
+        if (file == null || !file.exists()) return;
+        try {
+            String content = java.nio.file.Files.readString(file.toPath());
+            plantUmlParsingService.parseDomainModel(content);
+            updateSuggestions();
+        } catch (java.io.IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -198,11 +198,14 @@ public class EditorViewController {
                             currentPos = TextPos.ofLeading(lastParagraph, textLen);
                         }
 
-                        editorCodeArea.insertText(currentPos, newVal.text() + " ", null);
+                        editorCodeArea.insertText(currentPos, newVal.text(), null);
 
-                        int newOffset = currentPos.offset() + newVal.text().length() + 1;
-                        editorCodeArea.select(TextPos.ofLeading(newOffset, newOffset));
-
+                        // Move caret to end of inserted text.
+                        // TextPos.ofLeading(paragraphIndex, offsetInParagraph) – both values must be
+                        // in paragraph-space, NOT an absolute character offset.
+                        int newCharOffset = currentPos.offset() + newVal.text().length();
+                        TextPos afterInsert = TextPos.ofLeading(currentPos.index(), newCharOffset);
+                        editorCodeArea.select(afterInsert, afterInsert);
                         editorCodeArea.requestFocus();
                     } finally {
                         // Clear the command in ViewModel to allow repeated commands
@@ -249,11 +252,11 @@ public class EditorViewController {
                 }
             });
 
-            // Listen to caret position
+            // Listen to caret position – compute absolute char offset across all paragraphs
             editorCodeArea.caretPositionProperty().addListener((obs, oldVal, newVal) -> {
                 if (newVal != null) {
-                    int caretIndex = newVal.offset();
-                    viewModel.onCaretPositionChanged(caretIndex);
+                    int absoluteOffset = computeAbsoluteOffset(newVal);
+                    viewModel.onCaretPositionChanged(absoluteOffset);
                 }
             });
 
@@ -366,5 +369,21 @@ public class EditorViewController {
 
     private void updateEditorStyle(int size) {
         editorCodeArea.setStyle("-fx-font-family: 'Consolas', monospace; -fx-font-size: " + size + "pt;");
+    }
+
+    /**
+     * Converts a TextPos (paragraph + intra-paragraph offset) to an absolute
+     * character offset in the full text, counting each paragraph separator as one '\n'.
+     */
+    private int computeAbsoluteOffset(TextPos pos) {
+        if (pos == null) return 0;
+        int absolute = 0;
+        int paragraphIndex = pos.index();
+        for (int i = 0; i < paragraphIndex; i++) {
+            absolute += editorCodeArea.getModel().getPlainText(i).length();
+            absolute += 1; // newline separator between paragraphs
+        }
+        absolute += pos.offset();
+        return absolute;
     }
 }

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -58,6 +58,9 @@ public class EditorViewController {
     @FXML
     private javafx.scene.control.ComboBox<String> modelComboBox;
 
+    @FXML
+    private Button loadDomainModelButton;
+
     private EditorViewModel viewModel;
     private final TokenHighlightMappingService tokenHighlightMappingService;
 
@@ -81,6 +84,18 @@ public class EditorViewController {
                             }
                         }
                     );
+                }
+            });
+        }
+
+        if (loadDomainModelButton != null) {
+            loadDomainModelButton.setOnAction(e -> {
+                FileChooser fileChooser = new FileChooser();
+                fileChooser.setTitle("Load Domain Model (.puml)");
+                fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("PlantUML Files", "*.puml", "*.txt"));
+                File selectedFile = fileChooser.showOpenDialog(loadDomainModelButton.getScene().getWindow());
+                if (selectedFile != null) {
+                    this.viewModel.loadDomainModel(selectedFile);
                 }
             });
         }

--- a/src/main/resources/org/geantlr/views/EditorView.fxml
+++ b/src/main/resources/org/geantlr/views/EditorView.fxml
@@ -43,11 +43,23 @@
     </center>
 
     <bottom>
-        <FlowPane fx:id="suggestionsPane" hgap="5" vgap="5" style="-fx-background-color: -color-bg-subtle; -fx-border-color: -color-border-default; -fx-border-width: 1 0 0 0;">
-            <padding>
-                <Insets top="5" right="5" bottom="5" left="5"/>
-            </padding>
-        </FlowPane>
+        <VBox>
+            <FlowPane fx:id="suggestionsPane" hgap="5" vgap="5" style="-fx-background-color: -color-bg-subtle; -fx-border-color: -color-border-default; -fx-border-width: 1 0 0 0;">
+                <padding>
+                    <Insets top="5" right="5" bottom="5" left="5"/>
+                </padding>
+            </FlowPane>
+            <HBox spacing="10" alignment="CENTER_LEFT" style="-fx-background-color: -color-bg-subtle; -fx-border-color: -color-border-default; -fx-border-width: 1 0 0 0;">
+                <padding>
+                    <Insets top="5" right="5" bottom="5" left="5"/>
+                </padding>
+                <Button fx:id="loadDomainModelButton" text="Load Domain Model (.puml)" styleClass="button-outlined">
+                    <graphic>
+                        <FontIcon iconLiteral="mdi2f-file-tree" iconSize="16"/>
+                    </graphic>
+                </Button>
+            </HBox>
+        </VBox>
     </bottom>
 
 </BorderPane>

--- a/src/test/java/org/geantlr/services/PlantUmlParsingServiceTest.java
+++ b/src/test/java/org/geantlr/services/PlantUmlParsingServiceTest.java
@@ -1,0 +1,196 @@
+package org.geantlr.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlantUmlParsingServiceTest {
+
+    private PlantUmlParsingService service;
+
+    // The example PUML from the user (unclosed braces, single-line format)
+    private static final String EXAMPLE_PUML = "@startuml\n"
+        + "skinparam classAttributeIconSize 0\n"
+        + "skinparam linetype ortho\n"
+        + "hide empty methods\n"
+        + "title Klassendiagramm: Datenmodell QS-Tool mit Rückabbildbarkeit je Attribut\n"
+        + "\n"
+        + "rectangle \"Quellenmodell\" {\n"
+        + "\n"
+        + "abstract class QuellenRef\n"
+        + "\n"
+        + "class ExcelRef { datei: String\n blatt: String\n zeile: int\n spalte: String\n}\n"
+        + "\n"
+        + "note bottom of ExcelRef\n Spalte bezieht sich auf die Excel-Spalte\nend note\n"
+        + "\n"
+        + "class PlanProRef { datei: String\n objektTyp: String\n guid: String\n xpath: String\n}\n"
+        + "\n"
+        + "ExcelRef -up-|> QuellenRef\n"
+        + "PlanProRef -up-|> QuellenRef\n"
+        + "\n"
+        + "class WertMitQuelle { }\n"
+        + "\n"
+        + "WertMitQuelle \"1\" *-- \"1\" QuellenRef\n"
+        + "\n"
+        + "}\n"
+        + "\n"
+        + "rectangle \"Fachmodell Datenpunkt-Kontext\" {\n"
+        + "\n"
+        + "class DatenpunktKontextSammlung { DatenpunktKontexte: List\n}\n"
+        + "\n"
+        + "class DatenpunktKontext { datenpunkt: Datenpunkt\n bezugspunkt: Bezugspunkt\n kmSprung: KmSprung\n bmm: BigMetalMass\n bemerkungen: WertMitQuelle\n}\n"
+        + "\n"
+        + "class Balise { anordnungImDP: WertMitQuelle\n}\n"
+        + "\n"
+        + "}\n"
+        + "@enduml";
+
+    @BeforeEach
+    void setUp() {
+        service = new PlantUmlParsingService();
+    }
+
+    @Test
+    void testParsesClassesWithFields() {
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        assertFalse(cache.isEmpty(), "Domain model cache should not be empty");
+        assertTrue(cache.containsKey("ExcelRef"), "Should contain ExcelRef");
+        assertTrue(cache.containsKey("PlanProRef"), "Should contain PlanProRef");
+        assertTrue(cache.containsKey("DatenpunktKontext"), "Should contain DatenpunktKontext");
+        assertTrue(cache.containsKey("Balise"), "Should contain Balise");
+    }
+
+    @Test
+    void testExcelRefHasFields() {
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        DomainClass excelRef = cache.get("ExcelRef");
+        assertNotNull(excelRef, "ExcelRef should be in cache");
+        assertFalse(excelRef.fields().isEmpty(), "ExcelRef should have fields");
+        assertTrue(excelRef.fields().contains("datei"), "ExcelRef should have field 'datei'");
+        assertTrue(excelRef.fields().contains("blatt"), "ExcelRef should have field 'blatt'");
+        assertTrue(excelRef.fields().contains("zeile"), "ExcelRef should have field 'zeile'");
+        assertTrue(excelRef.fields().contains("spalte"), "ExcelRef should have field 'spalte'");
+    }
+
+    @Test
+    void testDatenpunktKontextHasFields() {
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        DomainClass ctx = cache.get("DatenpunktKontext");
+        assertNotNull(ctx, "DatenpunktKontext should be in cache");
+        assertFalse(ctx.fields().isEmpty(), "DatenpunktKontext should have fields");
+        assertTrue(ctx.fields().contains("datenpunkt"), "DatenpunktKontext should have field 'datenpunkt'");
+        assertTrue(ctx.fields().contains("bezugspunkt"), "DatenpunktKontext should have field 'bezugspunkt'");
+    }
+
+    @Test
+    void testSingleLinePuml() {
+        // Test with the single-line format (as received from user)
+        String singleLine = "@startuml skinparam classAttributeIconSize 0 "
+            + "class ExcelRef { datei: String blatt: String zeile: int spalte: String } "
+            + "@enduml";
+        service.parseDomainModel(singleLine);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        assertTrue(cache.containsKey("ExcelRef"), "Should parse ExcelRef from single-line format");
+        DomainClass excelRef = cache.get("ExcelRef");
+        assertFalse(excelRef.fields().isEmpty(), "ExcelRef should have fields in single-line format");
+        assertTrue(excelRef.fields().contains("datei"), "ExcelRef should have field 'datei' in single-line format");
+    }
+
+    @Test
+    void testFieldTypesAreCaptured() {
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        DomainClass ctx = cache.get("DatenpunktKontext");
+        assertNotNull(ctx);
+        assertFalse(ctx.fieldTypes().isEmpty(), "DatenpunktKontext should have field type mappings");
+        assertEquals("Datenpunkt", ctx.fieldTypes().get("datenpunkt"),
+            "Field 'datenpunkt' should map to type 'Datenpunkt'");
+        assertEquals("Bezugspunkt", ctx.fieldTypes().get("bezugspunkt"),
+            "Field 'bezugspunkt' should map to type 'Bezugspunkt'");
+    }
+
+    @Test
+    void testDatenpunktKontextDoesNotContainSammlungBackReference() {
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        DomainClass ctx = cache.get("DatenpunktKontext");
+        assertNotNull(ctx);
+        // The parent collection must NOT appear as a field on the child –
+        // DatenpunktKontextSammlung *-- DatenpunktKontext means the Sammlung owns the Kontext,
+        // not the other way around.
+        assertFalse(ctx.fields().contains("datenpunktKontextSammlung"),
+            "DatenpunktKontext must not have a back-reference field 'datenpunktKontextSammlung', actual fields: " + ctx.fields());
+        assertFalse(ctx.fields().contains("DatenpunktKontextSammlung"),
+            "DatenpunktKontext must not have 'DatenpunktKontextSammlung' as field");
+    }
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        DomainClass wmq = cache.get("WertMitQuelle");
+        assertNotNull(wmq, "WertMitQuelle should be in cache");
+        assertTrue(wmq.fields().contains("wert"),
+            "WertMitQuelle should have implicit 'wert' field");
+    }
+
+    @Test
+    void testWertMitQuelleHasQuelleFromRelation() {
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        DomainClass wmq = cache.get("WertMitQuelle");
+        assertNotNull(wmq, "WertMitQuelle should be in cache");
+        // "QuellenRef" → shortened to "quelle" via suffix-stripping of "Ref"
+        assertTrue(wmq.fields().contains("quelle") || wmq.fields().contains("quellenRef"),
+            "WertMitQuelle should have 'quelle' or 'quellenRef' from UML relation to QuellenRef, fields: " + wmq.fields());
+        // the relation field should point to QuellenRef
+        String quelleType = wmq.fieldTypes().getOrDefault("quelle", wmq.fieldTypes().get("quellenRef"));
+        assertEquals("QuellenRef", quelleType,
+            "quelle/quellenRef field should resolve to type QuellenRef");
+    }
+
+    @Test
+    void testChainedDotAccessResolution() {
+        service.parseDomainModel(EXAMPLE_PUML);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        // Simulate: DatenpunktKontext ctx → ctx.datenpunkt. → should give fields of Datenpunkt
+        DomainClass ctx = cache.get("DatenpunktKontext");
+        assertNotNull(ctx);
+        String datenpunktType = ctx.fieldTypes().get("datenpunkt");
+        assertEquals("Datenpunkt", datenpunktType);
+
+        DomainClass datenpunkt = cache.get("Datenpunkt");
+        assertNotNull(datenpunkt, "Datenpunkt class should be in cache");
+        assertFalse(datenpunkt.fields().isEmpty(), "Datenpunkt should have fields");
+    }
+        String pumlWithNotes = "@startuml\n"
+            + "class Foo {\n"
+            + "  bar: String\n"
+            + "}\n"
+            + "note bottom of Foo\n"
+            + "  this is a note with class keyword inside\n"
+            + "  class FakeClass { fakeField: String }\n"
+            + "end note\n"
+            + "@enduml";
+        service.parseDomainModel(pumlWithNotes);
+        Map<String, DomainClass> cache = service.getDomainModelCache();
+
+        assertFalse(cache.containsKey("FakeClass"), "Class inside note block should not be parsed");
+        assertTrue(cache.containsKey("Foo"), "Foo should be parsed");
+    }
+}
+
+
+


### PR DESCRIPTION
This feature enables domanin-specific IntelliSense by reading a PlantUML class diagram. When an object is typed, followed by a dot (e.g., `User.`), the editor's auto-completion now parses the cached PlantUML content, and suggests matching fields and methods for that specific class. 
The implementation reads the PUML into `PlantUmlParsingService`, caches the data as a map of class names to `DomainClass` records, and intercepts the candidate gathering process in `CodeCompletionService` to inject these domain-specific suggestions into the autocompletion menu.

---
*PR created automatically by Jules for task [8151746413877366534](https://jules.google.com/task/8151746413877366534) started by @tkpixel*