### PR TITLE
⚡ Bolt: Asynchronous Imports and Progress Indicators

### DIFF
--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -2,7 +2,11 @@ package org.geantlr.viewmodels;
 
 import io.micronaut.context.annotation.Prototype;
 import jakarta.inject.Inject;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -26,7 +30,7 @@ public class EditorViewModel {
     private static final Logger LOG = Logger.getLogger(EditorViewModel.class.getName());
 
     private final StringProperty textContent = new SimpleStringProperty("");
-    private final javafx.beans.property.IntegerProperty fontSize = new javafx.beans.property.SimpleIntegerProperty(13);
+    private final IntegerProperty fontSize = new SimpleIntegerProperty(13);
     private final ObservableList<SyntaxError> errors = FXCollections.observableArrayList();
     private final ObservableList<Token> tokens = FXCollections.observableArrayList();
     private final ObservableList<String> suggestedTokens = FXCollections.observableArrayList();
@@ -38,7 +42,8 @@ public class EditorViewModel {
 
     private final ObjectProperty<InsertTextCommand> insertTextCommand = new SimpleObjectProperty<>();
 
-    private final javafx.beans.property.BooleanProperty isGenerating = new javafx.beans.property.SimpleBooleanProperty(false);
+    private final BooleanProperty isGenerating = new SimpleBooleanProperty(false);
+    private final BooleanProperty isParsingDomainModel = new SimpleBooleanProperty(false);
 
     private final StringProperty referenceTemplate = new SimpleStringProperty("");
     private final StringProperty referenceTemplateName = new SimpleStringProperty("");
@@ -56,7 +61,7 @@ public class EditorViewModel {
     private final org.geantlr.services.RuleGenerationService ruleGenerationService;
     private final org.geantlr.services.PlantUmlParsingService plantUmlParsingService;
 
-    public javafx.beans.property.BooleanProperty experimentalModeProperty() {
+    public BooleanProperty experimentalModeProperty() {
         return mainViewModel != null ? mainViewModel.experimentalModeProperty() : null;
     }
 
@@ -213,7 +218,7 @@ public class EditorViewModel {
         this.textContent.set(text);
     }
 
-    public javafx.beans.property.IntegerProperty fontSizeProperty() {
+    public IntegerProperty fontSizeProperty() {
         return fontSize;
     }
 
@@ -237,7 +242,7 @@ public class EditorViewModel {
         return replaceTextCommand;
     }
 
-    public javafx.beans.property.BooleanProperty isGeneratingProperty() {
+    public BooleanProperty isGeneratingProperty() {
         return isGenerating;
     }
 
@@ -350,17 +355,64 @@ public class EditorViewModel {
             }
         });
 
-        new Thread(generationTask).start();
+        Thread.ofVirtual().start(generationTask);
     }
 
     public void loadDomainModel(java.io.File file) {
         if (file == null || !file.exists()) return;
-        try {
-            String content = java.nio.file.Files.readString(file.toPath());
-            plantUmlParsingService.parseDomainModel(content);
+
+        javafx.concurrent.Task<Void> parseTask = new javafx.concurrent.Task<>() {
+            @Override
+            protected Void call() throws Exception {
+                String content = java.nio.file.Files.readString(file.toPath());
+                plantUmlParsingService.parseDomainModel(content);
+                return null;
+            }
+        };
+
+        parseTask.setOnRunning(e -> isParsingDomainModel.set(true));
+        parseTask.setOnSucceeded(e -> {
+            isParsingDomainModel.set(false);
             updateSuggestions();
-        } catch (java.io.IOException e) {
-            LOG.severe("Failed to load domain model: " + e.getMessage());
-        }
+        });
+        parseTask.setOnFailed(e -> {
+            isParsingDomainModel.set(false);
+            Throwable ex = parseTask.getException();
+            LOG.severe("Failed to load domain model: " + (ex != null ? ex.getMessage() : "Unknown error"));
+        });
+
+        Thread.ofVirtual().start(parseTask);
+    }
+
+    public BooleanProperty isParsingDomainModelProperty() {
+        return isParsingDomainModel;
+    }
+
+    public boolean isParsingDomainModel() {
+        return isParsingDomainModel.get();
+    }
+
+    public void loadTemplateAsync(java.io.File file) {
+        if (file == null || !file.exists()) return;
+
+        javafx.concurrent.Task<String> loadTask = new javafx.concurrent.Task<>() {
+            @Override
+            protected String call() throws Exception {
+                return java.nio.file.Files.readString(file.toPath());
+            }
+        };
+
+        loadTask.setOnSucceeded(e -> {
+            String content = loadTask.getValue();
+            referenceTemplate.set(content);
+            referenceTemplateName.set("Template: " + file.getName());
+        });
+
+        loadTask.setOnFailed(e -> {
+            Throwable ex = loadTask.getException();
+            LOG.severe("Failed to read template file: " + (ex != null ? ex.getMessage() : "Unknown error"));
+        });
+
+        Thread.ofVirtual().start(loadTask);
     }
 }

--- a/src/main/java/org/geantlr/viewmodels/MainViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/MainViewModel.java
@@ -11,7 +11,11 @@ import jakarta.inject.Singleton;
 import jakarta.inject.Inject;
 import org.geantlr.services.DynamicGrammar;
 import org.geantlr.services.IGrammarLoaderService;
+import org.geantlr.services.TokenHighlightMappingService;
 import java.io.File;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.concurrent.Task;
 
 @Singleton
 public class MainViewModel {
@@ -26,6 +30,8 @@ public class MainViewModel {
 
     // Property to toggle experimental mode
     private final javafx.beans.property.BooleanProperty experimentalMode = new javafx.beans.property.SimpleBooleanProperty(false);
+
+    private final BooleanProperty isLoadingGrammar = new SimpleBooleanProperty(false);
 
     @Inject
     public MainViewModel(IGrammarLoaderService grammarLoaderService) {
@@ -87,5 +93,41 @@ public class MainViewModel {
 
     public DynamicGrammar loadDynamicGrammar(File grammarFile) throws Exception {
         return grammarLoaderService.loadDynamicGrammar(grammarFile);
+    }
+
+    public BooleanProperty isLoadingGrammarProperty() {
+        return isLoadingGrammar;
+    }
+
+    public boolean isLoadingGrammar() {
+        return isLoadingGrammar.get();
+    }
+
+    public Task<DynamicGrammar> loadGrammarAsync(File importDir, File parserFile, TokenHighlightMappingService tokenHighlightMappingService) {
+        Task<DynamicGrammar> task = new Task<>() {
+            @Override
+            protected DynamicGrammar call() throws Exception {
+                if (importDir != null) {
+                    grammarLoaderService.addImportDirectory(importDir);
+                }
+                DynamicGrammar grammar = grammarLoaderService.loadDynamicGrammar(importDir, parserFile);
+                if (grammar != null) {
+                    tokenHighlightMappingService.buildVocabularyMapping(grammar.getVocabulary());
+                }
+                return grammar;
+            }
+        };
+
+        task.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_RUNNING, e -> isLoadingGrammar.set(true));
+        task.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_SUCCEEDED, e -> {
+            isLoadingGrammar.set(false);
+            setDynamicGrammar(task.getValue());
+        });
+        task.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_FAILED, e -> isLoadingGrammar.set(false));
+        task.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_CANCELLED, e -> isLoadingGrammar.set(false));
+
+        Thread.ofVirtual().start(task);
+
+        return task;
     }
 }

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -56,6 +56,9 @@ public class EditorViewController {
     private ProgressIndicator generationProgress;
 
     @FXML
+    private ProgressIndicator domainModelProgress;
+
+    @FXML
     private Button selectTemplateButton;
 
     @FXML
@@ -229,15 +232,14 @@ public class EditorViewController {
                 fileChooser.setTitle("Select Template Rule File");
                 File selectedFile = fileChooser.showOpenDialog(selectTemplateButton.getScene().getWindow());
                 if (selectedFile != null) {
-                    try {
-                        String content = Files.readString(selectedFile.toPath());
-                        this.viewModel.referenceTemplateProperty().set(content);
-                        this.viewModel.referenceTemplateNameProperty().set("Template: " + selectedFile.getName());
-                    } catch (Exception ex) {
-                        LOG.severe("Failed to read template file: " + ex.getMessage());
-                    }
+                    this.viewModel.loadTemplateAsync(selectedFile);
                 }
             });
+        }
+
+        if (domainModelProgress != null) {
+            domainModelProgress.visibleProperty().bind(this.viewModel.isParsingDomainModelProperty());
+            domainModelProgress.managedProperty().bind(this.viewModel.isParsingDomainModelProperty());
         }
 
         if (editorCodeArea != null) {

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -26,10 +26,13 @@ import org.geantlr.viewmodels.EditorViewModel;
 import org.geantlr.viewmodels.MainViewModel;
 import org.geantlr.services.IGrammarLoaderService;
 import org.geantlr.services.DynamicGrammar;
+import org.geantlr.services.TokenHighlightMappingService;
 import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.stage.FileChooser;
 import javafx.stage.DirectoryChooser;
 import javafx.scene.control.Alert;
+import javafx.scene.control.ProgressBar;
+import javafx.concurrent.Task;
 
 @Singleton
 public class MainViewController {
@@ -52,8 +55,12 @@ public class MainViewController {
     @FXML
     private FontIcon themeIcon;
 
+    @FXML
+    private ProgressBar mainProgressBar;
+
     private final MainViewModel viewModel;
     private final IGrammarLoaderService grammarLoaderService;
+    private final TokenHighlightMappingService tokenHighlightMappingService;
     private final ApplicationContext context;
 
     private boolean isDarkMode = true;
@@ -62,14 +69,20 @@ public class MainViewController {
     private final Map<EditorViewModel, Region> editorRegions = new HashMap<>();
 
     @Inject
-    public MainViewController(MainViewModel viewModel, IGrammarLoaderService grammarLoaderService, ApplicationContext context) {
+    public MainViewController(MainViewModel viewModel, IGrammarLoaderService grammarLoaderService, TokenHighlightMappingService tokenHighlightMappingService, ApplicationContext context) {
         this.viewModel = viewModel;
         this.grammarLoaderService = grammarLoaderService;
+        this.tokenHighlightMappingService = tokenHighlightMappingService;
         this.context = context;
     }
 
     @FXML
     public void initialize() {
+        if (mainProgressBar != null) {
+            mainProgressBar.visibleProperty().bind(viewModel.isLoadingGrammarProperty());
+            mainProgressBar.managedProperty().bind(viewModel.isLoadingGrammarProperty());
+        }
+
         // Use an accent button style if provided by AtlantaFX
         themeToggleBtn.getStyleClass().addAll("accent", atlantafx.base.theme.Styles.BUTTON_ICON);
         themeToggleBtn.setAccessibleText("Toggle Theme");
@@ -198,24 +211,31 @@ public class MainViewController {
                 File importDir = controller.getImportDir();
                 File parserFile = controller.getParserFile();
 
-                if (importDir != null) {
-                    grammarLoaderService.addImportDirectory(importDir);
-                }
+                Task<DynamicGrammar> loadTask = viewModel.loadGrammarAsync(importDir, parserFile, tokenHighlightMappingService);
 
-                DynamicGrammar dynamicGrammar = grammarLoaderService.loadDynamicGrammar(importDir, parserFile);
-                viewModel.setDynamicGrammar(dynamicGrammar);
-                context.getBean(org.geantlr.services.TokenHighlightMappingService.class).buildVocabularyMapping(dynamicGrammar.getVocabulary());
+                loadTask.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_SUCCEEDED, e -> {
+                    DynamicGrammar dynamicGrammar = loadTask.getValue();
+                    Alert alert = new Alert(Alert.AlertType.INFORMATION);
+                    alert.setTitle("Grammar Loaded");
+                    alert.setHeaderText("Success");
+                    String rulesMsg = dynamicGrammar.getParserGrammar() != null
+                        ? "Parser rules: " + dynamicGrammar.getParserGrammar().rules.size()
+                        : "Lexer rules only";
 
-                Alert alert = new Alert(Alert.AlertType.INFORMATION);
-                alert.setTitle("Grammar Loaded");
-                alert.setHeaderText("Success");
-                String rulesMsg = dynamicGrammar.getParserGrammar() != null
-                    ? "Parser rules: " + dynamicGrammar.getParserGrammar().rules.size()
-                    : "Lexer rules only";
+                    alert.setContentText("Grammar '" + parserFile.getName() + "' loaded and compiled successfully.\n" +
+                                         rulesMsg);
+                    alert.showAndWait();
+                });
 
-                alert.setContentText("Grammar '" + parserFile.getName() + "' loaded and compiled successfully.\n" +
-                                     rulesMsg);
-                alert.showAndWait();
+                loadTask.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_FAILED, e -> {
+                    Throwable ex = loadTask.getException();
+                    Alert alert = new Alert(Alert.AlertType.ERROR);
+                    alert.setTitle("Error Loading Grammar");
+                    alert.setHeaderText("Failed to load or compile grammar");
+                    alert.setContentText(ex != null ? ex.getMessage() : "Unknown error");
+                    if (ex != null) ex.printStackTrace();
+                    alert.showAndWait();
+                });
             }
         } catch (Exception e) {
             Alert alert = new Alert(Alert.AlertType.ERROR);

--- a/src/main/resources/org/geantlr/views/EditorView.fxml
+++ b/src/main/resources/org/geantlr/views/EditorView.fxml
@@ -58,6 +58,7 @@
                         <FontIcon iconLiteral="mdi2f-file-tree" iconSize="16"/>
                     </graphic>
                 </Button>
+                <ProgressIndicator fx:id="domainModelProgress" visible="false" managed="false" prefWidth="20" prefHeight="20"/>
             </HBox>
         </VBox>
     </bottom>

--- a/src/main/resources/org/geantlr/views/MainView.fxml
+++ b/src/main/resources/org/geantlr/views/MainView.fxml
@@ -2,6 +2,7 @@
 
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ProgressBar?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.control.ToolBar?>
 <?import javafx.scene.layout.BorderPane?>
@@ -52,6 +53,7 @@
                     </graphic>
                 </Button>
             </ToolBar>
+            <ProgressBar fx:id="mainProgressBar" maxWidth="Infinity" progress="-1" visible="false" managed="false"/>
         </VBox>
     </top>
 


### PR DESCRIPTION
This PR addresses the issue where import functionalities (Grammar loading, PlantUML parsing, and Template loading) were blocking the JavaFX application thread. 

Key changes:
1. **Asynchronous Grammar Loading**: The grammar loading logic was moved from `MainViewController` to `MainViewModel`. It now runs in a background task (Virtual Thread). A `ProgressBar` was added to the `MainView` and bound to the loading state in the ViewModel.
2. **Asynchronous Domain Model Parsing**: The PlantUML parsing in `EditorViewModel` now runs in a background task. A `ProgressIndicator` was added next to the 'Load Domain Model' button in `EditorView`.
3. **Asynchronous Template Loading**: Rule template file reading was moved to a background task in `EditorViewModel`.
4. **Task Observer Pattern Fix**: Replaced `setOnSucceeded`/`setOnFailed` with `addEventHandler` to ensure that both the ViewModel (for state updates) and the Controller (for showing Alerts) can observe the same Task without overwriting each other's listeners.
5. **Architectural Improvements**: Replaced manual `new Thread()` calls with `Thread.ofVirtual().start()` and cleaned up imports in `EditorViewModel`.

Fixes #62

---
*PR created automatically by Jules for task [871933747656602075](https://jules.google.com/task/871933747656602075) started by @tkpixel*