### PR TITLE
🎨 Palette: [UX improvement] Add accessibility attributes to LoadGrammarDialog

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2023-10-27 - [Accessible Icon Buttons]
 **Learning:** When using AtlantaFX, removing text from buttons to save space requires adding `atlantafx.base.theme.Styles.BUTTON_ICON` to the style classes. More importantly, removing the text breaks screen reader support, so `setAccessibleText`, `setAccessibleHelp`, and a `Tooltip` must be explicitly added to maintain accessibility and provide visual hover context.
 **Action:** When creating icon-only buttons, always apply `Styles.BUTTON_ICON` and immediately add `setAccessibleText()`, `setAccessibleHelp()`, and `setTooltip()`.
+
+## 2026-03-31 - [Accessible Form Fields]
+**Learning:** Standard form fields in FXML, such as `TextField`, may have `promptText` that is visible to users, but it is important to explicitly add `accessibleText` and `accessibleHelp` attributes to these fields and related buttons to ensure screen readers provide full context and guidance.
+**Action:** When creating JavaFX forms and dialogs, explicitly set `accessibleText` and `accessibleHelp` attributes on standard form fields and buttons in the FXML.

--- a/src/main/resources/org/geantlr/views/LoadGrammarDialog.fxml
+++ b/src/main/resources/org/geantlr/views/LoadGrammarDialog.fxml
@@ -20,22 +20,22 @@
     <VBox spacing="5">
         <Label text="1. Set Import Directory (Optional, for external tokens/includes)" />
         <HBox spacing="10">
-            <TextField fx:id="importDirField" editable="false" HBox.hgrow="ALWAYS" promptText="Select directory..." />
-            <Button text="Browse" onAction="#selectImportDir" />
+            <TextField fx:id="importDirField" editable="false" HBox.hgrow="ALWAYS" promptText="Select directory..." accessibleText="Import Directory" accessibleHelp="The selected import directory for external tokens or includes." />
+            <Button text="Browse" onAction="#selectImportDir" accessibleText="Browse Import Directory" accessibleHelp="Opens a dialog to select the import directory." />
         </HBox>
     </VBox>
 
     <VBox spacing="5">
         <Label text="2. Load Parser / Combined Grammar (Required)" />
         <HBox spacing="10">
-            <TextField fx:id="parserFileField" editable="false" HBox.hgrow="ALWAYS" promptText="Select *Parser.g4 or *.g4..." />
-            <Button text="Browse" onAction="#selectParserFile" />
+            <TextField fx:id="parserFileField" editable="false" HBox.hgrow="ALWAYS" promptText="Select *Parser.g4 or *.g4..." accessibleText="Parser or Combined Grammar File" accessibleHelp="The selected ANTLR grammar file to load." />
+            <Button text="Browse" onAction="#selectParserFile" accessibleText="Browse Parser File" accessibleHelp="Opens a dialog to select the parser or combined grammar file." />
         </HBox>
     </VBox>
 
     <HBox spacing="10" alignment="CENTER_RIGHT">
-        <Button text="Cancel" onAction="#cancel" />
-        <Button fx:id="loadBtn" text="Load Grammar" onAction="#load" styleClass="accent" disable="true" />
+        <Button text="Cancel" onAction="#cancel" accessibleText="Cancel" accessibleHelp="Cancels loading grammar and closes the dialog." />
+        <Button fx:id="loadBtn" text="Load Grammar" onAction="#load" styleClass="accent" disable="true" accessibleText="Load Grammar" accessibleHelp="Loads the selected grammar files." />
     </HBox>
 
 </VBox>


### PR DESCRIPTION
💡 What: Added `accessibleText` and `accessibleHelp` attributes to the TextFields and Buttons in `LoadGrammarDialog.fxml`.
🎯 Why: To ensure screen reader users have clear context and guidance when using the grammar loading dialog.
📸 Before/After: N/A (non-visual change).
♿ Accessibility: Added screen reader text for inputs and action buttons in the dialog.

---
*PR created automatically by Jules for task [5010400185079141117](https://jules.google.com/task/5010400185079141117) started by @tkpixel*