### PR TITLE
Move model selection box next to template button

### DIFF
--- a/src/main/resources/org/geantlr/views/EditorView.fxml
+++ b/src/main/resources/org/geantlr/views/EditorView.fxml
@@ -27,11 +27,11 @@
                         <FontIcon iconLiteral="mdi2p-paperclip" iconSize="16"/>
                     </graphic>
                 </Button>
+                <javafx.scene.control.ComboBox fx:id="modelComboBox" promptText="Select Model..."/>
                 <Label fx:id="templateNameLabel" styleClass="tag" visible="false" managed="false"/>
             </HBox>
             <HBox spacing="10" alignment="CENTER_LEFT">
                 <TextArea fx:id="promptTextArea" promptText="Enter natural language prompt..." HBox.hgrow="ALWAYS" wrapText="true" prefRowCount="2"/>
-                <javafx.scene.control.ComboBox fx:id="modelComboBox" promptText="Select Model..."/>
                 <Button fx:id="generateButton" text="Generieren" styleClass="accent"/>
                 <ProgressIndicator fx:id="generationProgress" visible="false" prefWidth="20" prefHeight="20"/>
             </HBox>


### PR DESCRIPTION
Moved the experimental mode model selection box (`modelComboBox`) to sit to the right of the "Select Template" button in the UI. No backend logic changes were required, and tests continue to pass.

---
*PR created automatically by Jules for task [1005153354119802329](https://jules.google.com/task/1005153354119802329) started by @tkpixel*