### PR TITLE
Add Download Content feature to Main Menu

### DIFF
--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -180,12 +180,11 @@ public class MainViewController {
             saveEditorContent(viewModel.getActiveEditors().get(0));
         } else {
             Map<String, EditorViewModel> choices = new LinkedHashMap<>();
-            for (int i = 0; i < viewModel.getActiveEditors().size(); i++) {
-                choices.put("Editor " + (i + 1), viewModel.getActiveEditors().get(i));
-            }
+            choices.put("Left Editor", viewModel.getActiveEditors().get(0));
+            choices.put("Right Editor", viewModel.getActiveEditors().get(1));
 
             ChoiceDialog<String> stringDialog = new ChoiceDialog<>(
-                    "Editor 1", choices.keySet());
+                    "Left Editor", choices.keySet());
             stringDialog.setTitle("Select Editor");
             stringDialog.setHeaderText("Multiple editors are open.");
             stringDialog.setContentText("Choose which editor's content to download:");

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -20,6 +20,7 @@ import javafx.collections.ListChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.geantlr.FxmlControllerFactory;
 import org.geantlr.viewmodels.EditorViewModel;
@@ -33,6 +34,9 @@ import javafx.stage.DirectoryChooser;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ProgressBar;
 import javafx.concurrent.Task;
+import javafx.scene.control.ChoiceDialog;
+import java.nio.file.Files;
+import java.util.Optional;
 
 @Singleton
 public class MainViewController {
@@ -162,6 +166,62 @@ public class MainViewController {
             viewModel.addEditor(context.getBean(EditorViewModel.class));
         } else if (viewModel.getActiveEditors().size() == 2) {
             viewModel.removeEditor(viewModel.getActiveEditors().get(1));
+        }
+    }
+
+    @FXML
+    private void downloadContent() {
+        int numEditors = viewModel.getActiveEditors().size();
+        if (numEditors == 0) {
+            return;
+        }
+
+        if (numEditors == 1) {
+            saveEditorContent(viewModel.getActiveEditors().get(0));
+        } else {
+            Map<String, EditorViewModel> choices = new LinkedHashMap<>();
+            for (int i = 0; i < viewModel.getActiveEditors().size(); i++) {
+                choices.put("Editor " + (i + 1), viewModel.getActiveEditors().get(i));
+            }
+
+            ChoiceDialog<String> stringDialog = new ChoiceDialog<>(
+                    "Editor 1", choices.keySet());
+            stringDialog.setTitle("Select Editor");
+            stringDialog.setHeaderText("Multiple editors are open.");
+            stringDialog.setContentText("Choose which editor's content to download:");
+
+            Optional<String> result = stringDialog.showAndWait();
+            if (result.isPresent()) {
+                saveEditorContent(choices.get(result.get()));
+            }
+        }
+    }
+
+    private void saveEditorContent(EditorViewModel editor) {
+        FileChooser fileChooser = new FileChooser();
+        fileChooser.setTitle("Save Content");
+        fileChooser.getExtensionFilters().addAll(
+                new FileChooser.ExtensionFilter("Text Files", "*.txt"),
+                new FileChooser.ExtensionFilter("Java Files", "*.java"),
+                new FileChooser.ExtensionFilter("All Files", "*.*"));
+
+        File file = fileChooser.showSaveDialog(editorSplitPane.getScene().getWindow());
+        if (file != null) {
+            try {
+                Files.writeString(file.toPath(), editor.getTextContent());
+                Alert alert = new Alert(Alert.AlertType.INFORMATION);
+                alert.setTitle("File Saved");
+                alert.setHeaderText(null);
+                alert.setContentText("Content saved to " + file.getAbsolutePath());
+                alert.showAndWait();
+            } catch (IOException e) {
+                Alert alert = new Alert(Alert.AlertType.ERROR);
+                alert.setTitle("Error Saving File");
+                alert.setHeaderText("Failed to save content to file");
+                alert.setContentText(e.getMessage());
+                e.printStackTrace();
+                alert.showAndWait();
+            }
         }
     }
 

--- a/src/main/resources/org/geantlr/views/MainView.fxml
+++ b/src/main/resources/org/geantlr/views/MainView.fxml
@@ -50,6 +50,11 @@
                         <FontIcon iconLiteral="mdi2d-dots-horizontal" iconSize="20"/>
                     </graphic>
                     <items>
+                        <MenuItem text="Download Content" onAction="#downloadContent">
+                            <graphic>
+                                <FontIcon iconLiteral="mdi2d-download" iconSize="20"/>
+                            </graphic>
+                        </MenuItem>
                         <MenuItem text="Toggle Theme" onAction="#toggleTheme">
                             <graphic>
                                 <FontIcon fx:id="themeIcon" iconLiteral="mdi2w-white-balance-sunny" iconSize="20"/>


### PR DESCRIPTION
Implemented the Download Content feature requested. It checks the number of active editors and either directly shows a FileChooser or first shows a ChoiceDialog if multiple editors are open, as per the requirements. Extension filters have been added to the FileChooser.

---
*PR created automatically by Jules for task [14334100358394047511](https://jules.google.com/task/14334100358394047511) started by @tkpixel*