### PR TITLE
Change syntax operator color to pink for both light and dark themes

### DIFF
--- a/src/main/resources/org/geantlr/theme-light.css
+++ b/src/main/resources/org/geantlr/theme-light.css
@@ -8,7 +8,7 @@
     -geantlr-syntax-number:      #1750a0;
     -geantlr-syntax-comment:     #7a7a7a;
     -geantlr-syntax-annotation:  #8a6800;
-    -geantlr-syntax-operator:    #444444;
+    -geantlr-syntax-operator:    pink;
     -geantlr-tooltip-bg:         #ffffff;
     -geantlr-tooltip-fg:         #1a1a1a;
     -geantlr-tooltip-border:     #cccccc;

--- a/src/main/resources/org/geantlr/theme.css
+++ b/src/main/resources/org/geantlr/theme.css
@@ -18,7 +18,7 @@
     -geantlr-syntax-number:      #6897bb;
     -geantlr-syntax-comment:     #808080;
     -geantlr-syntax-annotation:  #bbb529;
-    -geantlr-syntax-operator:    #a9b7c6;
+    -geantlr-syntax-operator:    pink;
     -geantlr-tooltip-bg:         #3c3f41;
     -geantlr-tooltip-fg:         #bbbbbb;
     -geantlr-tooltip-border:     #646464;


### PR DESCRIPTION
Change syntax operator color to pink for both light and dark themes

Sets the CSS variable `-geantlr-syntax-operator` to `pink` in both `theme.css` and `theme-light.css`. This ensures that brackets and special characters remain visible and styled correctly across all theme modes, addressing an issue where switching from dark to light mode obscured these characters.

---
*PR created automatically by Jules for task [12207134226455300732](https://jules.google.com/task/12207134226455300732) started by @tkpixel*