### PR TITLE
Refactor: Move "View Grammar" button into the application dropdown menu

### DIFF
--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -11,6 +11,7 @@ import javafx.scene.control.Button;
 import javafx.application.Platform;
 import javafx.scene.control.SplitPane;
 import javafx.scene.layout.Region;
+import javafx.scene.control.MenuItem;
 import javafx.scene.layout.StackPane;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HeaderBar;
@@ -48,7 +49,7 @@ public class MainViewController {
     private SplitPane editorSplitPane;
 
     @FXML
-    private Button viewGrammarBtn;
+    private MenuItem viewGrammarMenuItem;
 
     @FXML
     private Button loadDomainModelButton;
@@ -87,11 +88,8 @@ public class MainViewController {
             });
         }
 
-        if (viewGrammarBtn != null) {
-            viewGrammarBtn.setAccessibleText("View Grammar");
-            viewGrammarBtn.setAccessibleHelp("Opens the currently loaded grammar in a new window.");
-            viewGrammarBtn.setTooltip(new javafx.scene.control.Tooltip("View Grammar"));
-            viewGrammarBtn.disableProperty().bind(viewModel.dynamicGrammarProperty().isNull());
+        if (viewGrammarMenuItem != null) {
+            viewGrammarMenuItem.disableProperty().bind(viewModel.dynamicGrammarProperty().isNull());
         }
 
 

--- a/src/main/resources/org/geantlr/theme.css
+++ b/src/main/resources/org/geantlr/theme.css
@@ -151,6 +151,10 @@
     -fx-background-radius: 10px;
 }
 
+.main-view .menu-button.flat {
+    -fx-border-color: transparent;
+}
+
 /* Epic 1: Pill Button Styling */
 .pill-button {
     -fx-background-radius: 15px;

--- a/src/main/resources/org/geantlr/views/MainView.fxml
+++ b/src/main/resources/org/geantlr/views/MainView.fxml
@@ -30,11 +30,6 @@
                         <FontIcon iconLiteral="mdi2f-file-code-outline" iconSize="20"/>
                     </graphic>
                 </Button>
-                <Button fx:id="viewGrammarBtn" text="View Grammar" onAction="#viewGrammar" styleClass="button-outlined">
-                    <graphic>
-                        <FontIcon iconLiteral="mdi2e-eye-outline" iconSize="20"/>
-                    </graphic>
-                </Button>
                 <Button fx:id="loadDomainModelButton" text="Load Domain Model (.puml)" onAction="#loadDomainModel" styleClass="button-outlined">
                     <graphic>
                         <FontIcon iconLiteral="mdi2f-file-tree" iconSize="16"/>
@@ -50,6 +45,11 @@
                         <FontIcon iconLiteral="mdi2d-dots-horizontal" iconSize="20"/>
                     </graphic>
                     <items>
+                        <MenuItem fx:id="viewGrammarMenuItem" text="View Grammar" onAction="#viewGrammar">
+                            <graphic>
+                                <FontIcon iconLiteral="mdi2e-eye-outline" iconSize="20"/>
+                            </graphic>
+                        </MenuItem>
                         <MenuItem text="Download Content" onAction="#downloadContent">
                             <graphic>
                                 <FontIcon iconLiteral="mdi2d-download" iconSize="20"/>

--- a/src/main/resources/org/geantlr/views/MainView.fxml
+++ b/src/main/resources/org/geantlr/views/MainView.fxml
@@ -40,9 +40,9 @@
                 <!-- Spacer -->
                 <HBox HBox.hgrow="ALWAYS" />
 
-                <MenuButton styleClass="button-outlined, button-icon, no-arrow">
+                <MenuButton styleClass="button-icon, no-arrow, flat">
                     <graphic>
-                        <FontIcon iconLiteral="mdi2d-dots-horizontal" iconSize="20"/>
+                        <FontIcon iconLiteral="mdi2m-menu" iconSize="20"/>
                     </graphic>
                     <items>
                         <MenuItem fx:id="viewGrammarMenuItem" text="View Grammar" onAction="#viewGrammar">


### PR DESCRIPTION
Relocates the "View Grammar" functionality from a standalone `Button` on the toolbar to a `MenuItem` inside the existing `MenuButton` to save space.
- Updated `MainView.fxml` to move the item and change its type.
- Updated `MainViewController.java` to inject `MenuItem` instead of `Button`.
- Removed unsupported accessibility and tooltip configuration (since `MenuItem` does not extend `Node`).
- Retained the existing `disableProperty()` binding and `onAction` method.

---
*PR created automatically by Jules for task [11775007647231711330](https://jules.google.com/task/11775007647231711330) started by @tkpixel*