### PR TITLE
🏛️ Archie: [MVVM refactoring] Remove View styling coupling from ViewModel

### DIFF
--- a/.jules/archie.md
+++ b/.jules/archie.md
@@ -1,3 +1,7 @@
 ## 2024-05-20 - [View Controllers Bypassing ViewModels]
 **Learning:** Found a pattern where JavaFX Controllers inject and directly call Micronaut domain services (like `IGrammarLoaderService`), bypassing the ViewModel layer. This breaks MVVM separation of concerns, as the View should only communicate with the ViewModel.
 **Action:** When inspecting controllers, ensure they only inject their respective ViewModels (and context for initial loading if strictly necessary) and delegate all business logic requests and domain service calls to the ViewModel instead.
+
+## 2026-04-01 - Prevented ViewModels from handling styling services
+**Learning:** Found an MVVM violation where `MainViewModel.loadGrammarAsync` accepted `TokenHighlightMappingService` (a CSS styling service) as a parameter. The ViewModel used it to rebuild the vocabulary mappings. This forced the ViewModel to coordinate UI-specific styling logic, breaking the rule that "CSS and visual states belong purely to the View."
+**Action:** Removed the `TokenHighlightMappingService` parameter from `MainViewModel.loadGrammarAsync`. Moved the `buildVocabularyMapping` call into `MainViewController`'s JavaFX Task success handler (`WorkerStateEvent.WORKER_STATE_SUCCEEDED`), keeping styling coordination strictly in the View layer.

--- a/src/main/java/org/geantlr/viewmodels/MainViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/MainViewModel.java
@@ -103,18 +103,14 @@ public class MainViewModel {
         return isLoadingGrammar.get();
     }
 
-    public Task<DynamicGrammar> loadGrammarAsync(File importDir, File parserFile, TokenHighlightMappingService tokenHighlightMappingService) {
+    public Task<DynamicGrammar> loadGrammarAsync(File importDir, File parserFile) {
         Task<DynamicGrammar> task = new Task<>() {
             @Override
             protected DynamicGrammar call() throws Exception {
                 if (importDir != null) {
                     grammarLoaderService.addImportDirectory(importDir);
                 }
-                DynamicGrammar grammar = grammarLoaderService.loadDynamicGrammar(importDir, parserFile);
-                if (grammar != null) {
-                    tokenHighlightMappingService.buildVocabularyMapping(grammar.getVocabulary());
-                }
-                return grammar;
+                return grammarLoaderService.loadDynamicGrammar(importDir, parserFile);
             }
         };
 

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -27,8 +27,8 @@ import org.geantlr.FxmlControllerFactory;
 import org.geantlr.viewmodels.EditorViewModel;
 import org.geantlr.viewmodels.MainViewModel;
 import org.geantlr.services.IGrammarLoaderService;
-import org.geantlr.services.DynamicGrammar;
 import org.geantlr.services.TokenHighlightMappingService;
+import org.geantlr.services.DynamicGrammar;
 import org.kordamp.ikonli.javafx.FontIcon;
 import javafx.stage.FileChooser;
 import javafx.stage.DirectoryChooser;
@@ -395,10 +395,13 @@ public class MainViewController {
                 File importDir = controller.getImportDir();
                 File parserFile = controller.getParserFile();
 
-                Task<DynamicGrammar> loadTask = viewModel.loadGrammarAsync(importDir, parserFile, tokenHighlightMappingService);
+                Task<DynamicGrammar> loadTask = viewModel.loadGrammarAsync(importDir, parserFile);
 
                 loadTask.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_SUCCEEDED, e -> {
                     DynamicGrammar dynamicGrammar = loadTask.getValue();
+                    if (dynamicGrammar != null) {
+                        tokenHighlightMappingService.buildVocabularyMapping(dynamicGrammar.getVocabulary());
+                    }
                     String rulesMsg = dynamicGrammar.getParserGrammar() != null
                         ? "Parser rules: " + dynamicGrammar.getParserGrammar().rules.size()
                         : "Lexer rules only";


### PR DESCRIPTION
**💡 What:** Removed `TokenHighlightMappingService` from `MainViewModel` and its `loadGrammarAsync` parameter list. The CSS mapping logic is now called inside the JavaFX Application Thread event handler (`WORKER_STATE_SUCCEEDED`) in `MainViewController`.

**🎯 Why:** `TokenHighlightMappingService` is a styling-specific domain service that maps tokens to CSS classes. Passing it to the ViewModel violated the architectural rule that "CSS and visual states belong purely to the View." By handling it in the View's task event handler, the ViewModel is completely ignorant of CSS styling.

**🧪 Testability:** `MainViewModel` is now easier to instantiate and test in isolation, as it no longer requires a mock or instance of a UI styling service for the `loadGrammarAsync` domain operation.

---
*PR created automatically by Jules for task [5333101556288685463](https://jules.google.com/task/5333101556288685463) started by @tkpixel*