### PR TITLE
🎨 Palette: Improve Generator Button Accessibility & Feedback

### DIFF
--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -55,9 +55,6 @@ public class EditorViewController {
     private Button generateButton;
 
     @FXML
-    private ProgressIndicator generationProgress;
-
-    @FXML
     private Button selectTemplateButton;
 
     @FXML
@@ -260,10 +257,21 @@ public class EditorViewController {
     public void setViewModel(EditorViewModel viewModel) {
         this.viewModel = viewModel;
 
-        if (generateButton != null && promptTextArea != null && generationProgress != null && experimentalBox != null) {
-            generationProgress.visibleProperty().bind(this.viewModel.isGeneratingProperty());
+        if (generateButton != null && promptTextArea != null && experimentalBox != null) {
             generateButton.disableProperty().bind(this.viewModel.isGeneratingProperty().or(this.viewModel.selectedOllamaModelProperty().isNull()));
             selectTemplateButton.disableProperty().bind(this.viewModel.isGeneratingProperty());
+
+            this.viewModel.isGeneratingProperty().addListener((obs, oldVal, newVal) -> {
+                if (newVal) {
+                    ProgressIndicator pi = new ProgressIndicator();
+                    pi.setPrefSize(16, 16);
+                    generateButton.setGraphic(pi);
+                } else {
+                    org.kordamp.ikonli.javafx.FontIcon icon = new org.kordamp.ikonli.javafx.FontIcon("mdi2f-flask-outline");
+                    icon.setIconSize(16);
+                    generateButton.setGraphic(icon);
+                }
+            });
 
             experimentalBox.visibleProperty().bind(this.viewModel.experimentalModeProperty());
             experimentalBox.managedProperty().bind(this.viewModel.experimentalModeProperty());

--- a/src/main/resources/org/geantlr/views/EditorView.fxml
+++ b/src/main/resources/org/geantlr/views/EditorView.fxml
@@ -32,9 +32,12 @@
                 <Label fx:id="templateNameLabel" styleClass="tag" visible="false" managed="false"/>
             </HBox>
             <HBox spacing="10" alignment="CENTER_LEFT">
-                <TextArea fx:id="promptTextArea" promptText="Enter natural language prompt..." HBox.hgrow="ALWAYS" wrapText="true" prefRowCount="2"/>
-                <Button fx:id="generateButton" text="Generieren" styleClass="accent"/>
-                <ProgressIndicator fx:id="generationProgress" visible="false" prefWidth="20" prefHeight="20"/>
+                <TextArea fx:id="promptTextArea" promptText="Enter natural language prompt..." HBox.hgrow="ALWAYS" wrapText="true" prefRowCount="2" accessibleText="Prompt Text Area" accessibleHelp="Enter the natural language prompt for rule generation"/>
+                <Button fx:id="generateButton" text="Generieren" styleClass="accent" accessibleText="Generate Rules" accessibleHelp="Generate ANTLR rules based on the prompt">
+                    <graphic>
+                        <FontIcon iconLiteral="mdi2f-flask-outline" iconSize="16"/>
+                    </graphic>
+                </Button>
             </HBox>
         </VBox>
     </top>


### PR DESCRIPTION
💡 **What:** 
- Added screen reader attributes (`accessibleText`, `accessibleHelp`) to the Prompt Text Area and Generate Button in `EditorView.fxml`.
- Replaced the separate `ProgressIndicator` node with dynamic logic in `EditorViewController.java` that swaps the `generateButton`'s graphic between a `FontIcon` ("mdi2f-flask-outline") and a `ProgressIndicator` based on the `isGeneratingProperty()`.

🎯 **Why:** 
This micro-UX improvement creates a cleaner, more intuitive interface by embedding the loading state directly within the primary action button. It also significantly improves accessibility for screen readers by providing explicit context for the text area and button.

📸 **Before/After:** 
- **Before:** Separate, invisible `ProgressIndicator` node next to the button; button had no graphic and lacked a11y context.
- **After:** Button displays an icon, swaps to a progress spinner during generation, and provides full a11y context.

♿ **Accessibility:** Added screen reader text for the input text area and the generation button.

---
*PR created automatically by Jules for task [7104245324203793502](https://jules.google.com/task/7104245324203793502) started by @tkpixel*