### PR TITLE
🎨 Palette: [UX improvement] embed generation progress in button

### DIFF
--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -55,9 +55,6 @@ public class EditorViewController {
     private Button generateButton;
 
     @FXML
-    private ProgressIndicator generationProgress;
-
-    @FXML
     private Button selectTemplateButton;
 
     @FXML
@@ -260,8 +257,17 @@ public class EditorViewController {
     public void setViewModel(EditorViewModel viewModel) {
         this.viewModel = viewModel;
 
-        if (generateButton != null && promptTextArea != null && generationProgress != null && experimentalBox != null) {
-            generationProgress.visibleProperty().bind(this.viewModel.isGeneratingProperty());
+        if (generateButton != null && promptTextArea != null && experimentalBox != null) {
+            javafx.scene.Node originalGraphic = generateButton.getGraphic();
+            this.viewModel.isGeneratingProperty().addListener((obs, oldVal, newVal) -> {
+                if (newVal) {
+                    ProgressIndicator spinner = new ProgressIndicator();
+                    spinner.setPrefSize(16, 16);
+                    generateButton.setGraphic(spinner);
+                } else {
+                    generateButton.setGraphic(originalGraphic);
+                }
+            });
             generateButton.disableProperty().bind(this.viewModel.isGeneratingProperty().or(this.viewModel.selectedOllamaModelProperty().isNull()));
             selectTemplateButton.disableProperty().bind(this.viewModel.isGeneratingProperty());
 

--- a/src/main/resources/org/geantlr/views/EditorView.fxml
+++ b/src/main/resources/org/geantlr/views/EditorView.fxml
@@ -32,9 +32,14 @@
                 <Label fx:id="templateNameLabel" styleClass="tag" visible="false" managed="false"/>
             </HBox>
             <HBox spacing="10" alignment="CENTER_LEFT">
-                <TextArea fx:id="promptTextArea" promptText="Enter natural language prompt..." HBox.hgrow="ALWAYS" wrapText="true" prefRowCount="2"/>
-                <Button fx:id="generateButton" text="Generieren" styleClass="accent"/>
-                <ProgressIndicator fx:id="generationProgress" visible="false" prefWidth="20" prefHeight="20"/>
+                <TextArea fx:id="promptTextArea" promptText="Enter natural language prompt..." HBox.hgrow="ALWAYS" wrapText="true" prefRowCount="2"
+                          accessibleText="Prompt Input" accessibleHelp="Enter the natural language prompt to generate rules."/>
+                <Button fx:id="generateButton" text="Generate" styleClass="accent"
+                        accessibleText="Generate Rule" accessibleHelp="Generates a grammar rule based on the prompt.">
+                    <graphic>
+                        <FontIcon iconLiteral="mdi2a-auto-fix" iconSize="16"/>
+                    </graphic>
+                </Button>
             </HBox>
         </VBox>
     </top>


### PR DESCRIPTION
💡 What: Embedded the generation ProgressIndicator directly into the "Generate" button instead of keeping it as a standalone node. Changed the text from "Generieren" to "Generate". Added accessibleText and accessibleHelp.
🎯 Why: Makes the UI more compact, aligns with the prompt's language, and improves accessibility for screen readers.
♿ Accessibility: Added `accessibleText="Generate Rule"` and `accessibleHelp="Generates a grammar rule based on the prompt."` to the Generate button and `accessibleText="Prompt Input"` to the prompt text area.

---
*PR created automatically by Jules for task [11384185754780092913](https://jules.google.com/task/11384185754780092913) started by @tkpixel*