### PR TITLE
📡 Sonar: [Code quality improvement] Replace e.printStackTrace() with proper SLF4J logging

### DIFF
--- a/src/main/java/org/geantlr/services/GrammarLoaderService.java
+++ b/src/main/java/org/geantlr/services/GrammarLoaderService.java
@@ -4,6 +4,8 @@ import jakarta.inject.Singleton;
 import org.antlr.v4.Tool;
 import org.antlr.v4.tool.Grammar;
 import org.antlr.v4.tool.LexerGrammar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,6 +23,8 @@ import java.util.stream.Stream;
 @Singleton
 public class GrammarLoaderService implements IGrammarLoaderService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(GrammarLoaderService.class);
+
     private final List<File> importDirectories = new ArrayList<>();
 
     @Override
@@ -35,7 +39,7 @@ public class GrammarLoaderService implements IGrammarLoaderService {
                     .filter(p -> p.toString().endsWith(".g4"))
                     .collect(Collectors.toList());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Failed to read directory while finding grammar files: {}", directory, e);
             return Collections.emptyList();
         }
     }

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -39,9 +39,13 @@ import javafx.scene.control.ChoiceDialog;
 import java.nio.file.Files;
 import java.util.Optional;
 import javafx.application.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Singleton
 public class MainViewController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MainViewController.class);
 
     @FXML
     private HeaderBar headerBar;
@@ -213,11 +217,11 @@ public class MainViewController {
                 alert.setContentText("Content saved to " + file.getAbsolutePath());
                 alert.showAndWait();
             } catch (IOException e) {
+                LOG.error("Failed to save content to file: {}", file.getAbsolutePath(), e);
                 Alert alert = new Alert(Alert.AlertType.ERROR);
                 alert.setTitle("Error Saving File");
                 alert.setHeaderText("Failed to save content to file");
                 alert.setContentText(e.getMessage());
-                e.printStackTrace();
                 alert.showAndWait();
             }
         }
@@ -313,7 +317,7 @@ public class MainViewController {
             stage.setScene(dialogScene);
             stage.showAndWait();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Failed to load MessageDialog view for title: {}", title, e);
             // Fallback to standard alert if custom dialog fails
             Alert alert = new Alert(Alert.AlertType.INFORMATION);
             alert.setTitle(title);
@@ -360,7 +364,7 @@ public class MainViewController {
             stage.setScene(grammarScene);
             stage.show();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Failed to load GrammarView", e);
             showMessageDialog("Error Displaying Grammar", "Failed to load grammar view", e.getMessage());
         }
     }
@@ -411,12 +415,14 @@ public class MainViewController {
 
                 loadTask.addEventHandler(javafx.concurrent.WorkerStateEvent.WORKER_STATE_FAILED, e -> {
                     Throwable ex = loadTask.getException();
-                    if (ex != null) ex.printStackTrace();
+                    if (ex != null) {
+                        LOG.error("Task failed to load or compile grammar", ex);
+                    }
                     Platform.runLater(() -> showMessageDialog("Error Loading Grammar", "Failed to load or compile grammar", ex != null ? ex.getMessage() : "Unknown error"));
                 });
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error("Unexpected error occurred while preparing to load grammar", e);
             Platform.runLater(() -> showMessageDialog("Error Loading Grammar", "Failed to load or compile grammar", e.getMessage()));
         }
     }
@@ -430,7 +436,7 @@ public class MainViewController {
             controller.setViewModel(editorViewModel);
             return region;
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Failed to load EditorView", e);
             StackPane pane = new StackPane(new Label("Error loading editor"));
             pane.setStyle("-fx-border-color: red; -fx-background-color: -color-bg-default;");
             return pane;


### PR DESCRIPTION
Replaced raw `e.printStackTrace()` calls with structured SLF4J logging in `MainViewController` and `GrammarLoaderService`.

**Why:** `e.printStackTrace()` prints to `System.err` which is hard to monitor, capture, or format in production environments. Using SLF4J logging makes errors searchable and maintains a professional structure.

**Rule:** "Empty catch blocks or simply doing e.printStackTrace() instead of proper logging/handling."

---
*PR created automatically by Jules for task [4540472874781743881](https://jules.google.com/task/4540472874781743881) started by @tkpixel*