### PR TITLE
⚒️ Forge: Add automated GitHub Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: maven
+
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Set up JDK 25-ea
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25-ea'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build with Maven
+        if: ${{ steps.release.outputs.release_created }}
+        run: ./mvnw clean verify
+
+      - name: Upload Release Artifact
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ steps.release.outputs.tag_name }} target/*.jar


### PR DESCRIPTION
🚀 What: Created `.github/workflows/release.yml` which uses `release-please-action@v4` to automate GitHub Releases based on conventional commits. It also builds and uploads the resulting `.jar` artifact to the release.
⏱️ Impact: Eliminates manual tag and release creation, ensuring consistent release notes and binary uploads every time the project is cut.
⚙️ Config: No extra manual secrets are needed, but verify that `GITHUB_TOKEN` is permitted to create releases and push tags in the repository settings.

---
*PR created automatically by Jules for task [3139140998840063674](https://jules.google.com/task/3139140998840063674) started by @tkpixel*