### PR TITLE
⚡ Bolt: [performance improvement] Fix severe JavaFX memory leaks by cleaning up un-removed scene stylesheet listeners

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [Avoid Regex on Single-Line Tokens]
 **Learning:** During syntax highlighting in `EditorViewModel.computeTokenStyles`, performing `String.split("\r?\n", -1)` on every single token causes heavy regex compilation and array allocation overhead, especially because the vast majority of tokens are single-line strings.
 **Action:** Use a fast-path check `text.indexOf('\n') == -1` to completely bypass regex processing and array allocation for single-line tokens.
+
+## 2026-04-14 - Fix Scene Listener Memory Leaks
+**Learning:** In JavaFX, adding an anonymous or lambda listener to `Scene.getStylesheets()` inside an element's `sceneProperty()` listener (or any short-lived UI dialog) creates a hard reference from the globally long-lived `Scene` back to the short-lived node/dialog. Because `getStylesheets().addListener(...)` expects a `ListChangeListener`, which is strongly held by the observable list, the entire Controller/UI (and all its bindings) is kept alive in memory forever unless explicitly removed.
+**Action:** Always store `ListChangeListener`s (like stylesheet synchronizers) in strongly-referenced class fields and explicitly remove them using `.removeListener()` when the node's `sceneProperty` changes or when the dialog window/Stage is closed (`stage.setOnHidden(...)`).

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -100,6 +100,14 @@ public class EditorViewController {
     private final TokenHighlightMappingService tokenHighlightMappingService;
     private javafx.scene.canvas.Canvas bracketCanvas;
 
+    // Strongly referenced listener to prevent premature garbage collection
+    // and allow explicit removal to prevent memory leaks.
+    private final javafx.collections.ListChangeListener<String> stylesheetsListener = _ -> {
+        if (editorCodeArea.getScene() != null) {
+            syncTooltipStylesheets(editorCodeArea.getScene());
+        }
+    };
+
     @Inject
     public EditorViewController(TokenHighlightMappingService tokenHighlightMappingService) {
         this.tokenHighlightMappingService = tokenHighlightMappingService;
@@ -179,12 +187,14 @@ public class EditorViewController {
                 hoverPause.stop();
             });
 
-            editorCodeArea.sceneProperty().addListener((_, _, newScene) -> {
+            editorCodeArea.sceneProperty().addListener((_, oldScene, newScene) -> {
+                if (oldScene != null) {
+                    oldScene.getStylesheets().removeListener(stylesheetsListener);
+                }
                 if (newScene != null) {
                     // Tooltip-CSS mit der Scene synchron halten
                     syncTooltipStylesheets(newScene);
-                    newScene.getStylesheets().addListener((javafx.collections.ListChangeListener<String>) _ ->
-                        syncTooltipStylesheets(newScene));
+                    newScene.getStylesheets().addListener(stylesheetsListener);
                 }
             });
 

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -304,10 +304,10 @@ public class MainViewController {
             javafx.scene.Scene mainScene = editorSplitPane.getScene();
             if (mainScene != null) {
                 dialogScene.getStylesheets().setAll(mainScene.getStylesheets());
-                mainScene.getStylesheets().addListener(
-                    (javafx.collections.ListChangeListener<String>) _ ->
-                        dialogScene.getStylesheets().setAll(mainScene.getStylesheets())
-                );
+                javafx.collections.ListChangeListener<String> listener = _ ->
+                        dialogScene.getStylesheets().setAll(mainScene.getStylesheets());
+                mainScene.getStylesheets().addListener(listener);
+                stage.setOnHidden(e -> mainScene.getStylesheets().removeListener(listener));
             }
 
             stage.setScene(dialogScene);
@@ -383,10 +383,10 @@ public class MainViewController {
             javafx.scene.Scene mainScene = editorSplitPane.getScene();
             if (mainScene != null) {
                 dialogScene.getStylesheets().setAll(mainScene.getStylesheets());
-                mainScene.getStylesheets().addListener(
-                    (javafx.collections.ListChangeListener<String>) _ ->
-                        dialogScene.getStylesheets().setAll(mainScene.getStylesheets())
-                );
+                javafx.collections.ListChangeListener<String> listener = _ ->
+                        dialogScene.getStylesheets().setAll(mainScene.getStylesheets());
+                mainScene.getStylesheets().addListener(listener);
+                dialogStage.setOnHidden(e -> mainScene.getStylesheets().removeListener(listener));
             }
             dialogStage.setScene(dialogScene);
             dialogStage.showAndWait();


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Fix severe JavaFX memory leaks by cleaning up un-removed scene stylesheet listeners

💡 What: Stored Scene stylesheet ListChangeListeners in strongly-referenced fields and explicitly un-registered them via removeListener() when editor Scenes change or Dialog stages are hidden.
🎯 Why: Anonymous/lambda listeners attached to a globally long-lived object (Scene.getStylesheets) from short-lived views (like Editors or Dialogs) kept the entire Controller and UI graph alive in memory indefinitely.
📊 Impact: Prevents catastrophic memory ballooning as users open/close grammar tabs or spawn system dialogs. Reduces garbage collection pressure and prevents OOM crashes on long sessions.
🔬 Measurement: Run the app, open several Editor tabs and Dialogs, close them, and observe heap usage drop significantly after GC, rather than climbing linearly.

---
*PR created automatically by Jules for task [79844424812248230](https://jules.google.com/task/79844424812248230) started by @tkpixel*