### PR TITLE
🏛️ Archie: [MVVM refactoring] Remove JavaFX dependencies from ViewModels

### DIFF
--- a/.jules/archie.md
+++ b/.jules/archie.md
@@ -5,3 +5,7 @@
 ## 2026-04-01 - Prevented ViewModels from handling styling services
 **Learning:** Found an MVVM violation where `MainViewModel.loadGrammarAsync` accepted `TokenHighlightMappingService` (a CSS styling service) as a parameter. The ViewModel used it to rebuild the vocabulary mappings. This forced the ViewModel to coordinate UI-specific styling logic, breaking the rule that "CSS and visual states belong purely to the View."
 **Action:** Removed the `TokenHighlightMappingService` parameter from `MainViewModel.loadGrammarAsync`. Moved the `buildVocabularyMapping` call into `MainViewController`'s JavaFX Task success handler (`WorkerStateEvent.WORKER_STATE_SUCCEEDED`), keeping styling coordination strictly in the View layer.
+
+## 2026-05-31 - [Moved Debouncing to View Layer]
+**Learning:** Discovered an MVVM violation where `EditorViewModel` managed input rate-limiting using `javafx.animation.PauseTransition`. Because `PauseTransition` relies on the JavaFX Toolkit (which must be initialized), its presence in the ViewModel prevented pure, headless unit testing and coupled the ViewModel strictly to the JavaFX Application Thread.
+**Action:** Moved the instantiation and management of `PauseTransition` into the `EditorViewController` (the View layer). The View now listens to ViewModel property changes, handles the timers, and invokes simple action methods on the ViewModel (like `triggerParse()` or `executeSearch()`) upon timer completion. This cleanly decouples the ViewModel from JavaFX animations.

--- a/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
+++ b/src/main/java/org/geantlr/viewmodels/EditorViewModel.java
@@ -17,9 +17,7 @@ import org.geantlr.services.CodeCompletionService;
 import org.geantlr.services.CodeFormattingService;
 import org.geantlr.services.SyntaxError;
 import org.antlr.v4.runtime.Token;
-import javafx.animation.PauseTransition;
 import javafx.application.Platform;
-import javafx.util.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
@@ -60,7 +58,6 @@ public class EditorViewModel {
 
     public record SearchMatch(int start, int end) {}
     private final ObservableList<SearchMatch> searchMatches = FXCollections.observableArrayList();
-    private final PauseTransition searchDebounce = new PauseTransition(Duration.millis(150));
 
     private final ObservableList<String> availableOllamaModels = FXCollections.observableArrayList();
     private final ObjectProperty<String> selectedOllamaModel = new SimpleObjectProperty<>();
@@ -81,7 +78,6 @@ public class EditorViewModel {
         return mainViewModel != null ? mainViewModel.experimentalModeProperty() : null;
     }
 
-    private final PauseTransition debounce = new PauseTransition(Duration.millis(300));
 
     public record ReplaceTextCommand(String text) {}
     private final ObjectProperty<ReplaceTextCommand> replaceTextCommand = new SimpleObjectProperty<>();
@@ -95,29 +91,14 @@ public class EditorViewModel {
         this.ruleGenerationService = ruleGenerationService;
         this.plantUmlParsingService = plantUmlParsingService;
 
-        debounce.setOnFinished(_ -> {
-            parseText(textContent.get());
-            isTyping.set(false);
-            updateSuggestions();
-        });
 
-        textContent.addListener((_, _, _) -> {
-            isTyping.set(true);
-            debounce.playFromStart();
-            searchDebounce.playFromStart();
-        });
 
-        searchDebounce.setOnFinished(_ -> executeSearch());
 
-        searchText.addListener((_, _, _) -> searchDebounce.playFromStart());
-        searchMatchCase.addListener((_, _, _) -> searchDebounce.playFromStart());
-        searchWholeWord.addListener((_, _, _) -> searchDebounce.playFromStart());
-        searchRegex.addListener((_, _, _) -> searchDebounce.playFromStart());
 
         loadAvailableOllamaModels();
     }
 
-    private void executeSearch() {
+    public void executeSearch() {
         String query = searchText.get();
         String text = textContent.get();
 
@@ -232,6 +213,13 @@ public class EditorViewModel {
                 availableOllamaModels.setAll(models);
             });
         });
+    }
+
+
+    public void triggerParse() {
+        parseText(textContent.get());
+        isTyping.set(false);
+        updateSuggestions();
     }
 
     private void parseText(String text) {

--- a/src/main/java/org/geantlr/views/EditorViewController.java
+++ b/src/main/java/org/geantlr/views/EditorViewController.java
@@ -97,6 +97,9 @@ public class EditorViewController {
     private double lastScreenX, lastScreenY;
 
     private EditorViewModel viewModel;
+    private final PauseTransition typingDebounce = new PauseTransition(Duration.millis(300));
+    private final PauseTransition searchDebounce = new PauseTransition(Duration.millis(150));
+
     private final TokenHighlightMappingService tokenHighlightMappingService;
     private javafx.scene.canvas.Canvas bracketCanvas;
 
@@ -270,6 +273,25 @@ public class EditorViewController {
 
     public void setViewModel(EditorViewModel viewModel) {
         this.viewModel = viewModel;
+
+        typingDebounce.setOnFinished(_ -> {
+            viewModel.triggerParse();
+        });
+
+        searchDebounce.setOnFinished(_ -> {
+            viewModel.executeSearch();
+        });
+
+        this.viewModel.textContentProperty().addListener((_, _, newVal) -> {
+            viewModel.isTypingProperty().set(true);
+            typingDebounce.playFromStart();
+            searchDebounce.playFromStart();
+        });
+
+        this.viewModel.searchTextProperty().addListener((_, _, _) -> searchDebounce.playFromStart());
+        this.viewModel.searchMatchCaseProperty().addListener((_, _, _) -> searchDebounce.playFromStart());
+        this.viewModel.searchWholeWordProperty().addListener((_, _, _) -> searchDebounce.playFromStart());
+        this.viewModel.searchRegexProperty().addListener((_, _, _) -> searchDebounce.playFromStart());
 
         if (generateButton != null && promptTextArea != null && experimentalBox != null) {
             javafx.scene.Node originalGraphic = generateButton.getGraphic();

--- a/src/main/java/org/geantlr/views/MainViewController.java
+++ b/src/main/java/org/geantlr/views/MainViewController.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.geantlr.FxmlControllerFactory;
 import org.geantlr.viewmodels.EditorViewModel;
 import org.geantlr.viewmodels.MainViewModel;
-import org.geantlr.services.IGrammarLoaderService;
 import org.geantlr.services.TokenHighlightMappingService;
 import org.geantlr.services.DynamicGrammar;
 import org.kordamp.ikonli.javafx.FontIcon;
@@ -63,7 +62,6 @@ public class MainViewController {
     private ProgressBar mainProgressBar;
 
     private final MainViewModel viewModel;
-    private final IGrammarLoaderService grammarLoaderService;
     private final TokenHighlightMappingService tokenHighlightMappingService;
     private final ApplicationContext context;
 
@@ -73,9 +71,8 @@ public class MainViewController {
     private final Map<EditorViewModel, Region> editorRegions = new HashMap<>();
 
     @Inject
-    public MainViewController(MainViewModel viewModel, IGrammarLoaderService grammarLoaderService, TokenHighlightMappingService tokenHighlightMappingService, ApplicationContext context) {
+    public MainViewController(MainViewModel viewModel, TokenHighlightMappingService tokenHighlightMappingService, ApplicationContext context) {
         this.viewModel = viewModel;
-        this.grammarLoaderService = grammarLoaderService;
         this.tokenHighlightMappingService = tokenHighlightMappingService;
         this.context = context;
     }


### PR DESCRIPTION
💡 What: 
- Removed `javafx.animation.PauseTransition` from `EditorViewModel`.
- Handled debouncing for typing and search operations strictly inside `EditorViewController`.
- Added `triggerParse()` and made `executeSearch()` public in `EditorViewModel`.
- Removed `IGrammarLoaderService` dependency from `MainViewController`.

🎯 Why: 
- `PauseTransition` relies on the JavaFX Toolkit thread. Its presence in the ViewModel prevented pure unit testing (requiring TestFX initialization). Moving rate-limiting UI logic to the View strictly enforces MVVM.
- `MainViewController` was injecting `IGrammarLoaderService` directly, which violates MVVM boundaries where domain logic should only be accessed via the ViewModel.

🧪 Testability: 
- `EditorViewModel` can now be instantiated completely headlessly in JUnit tests without throwing JavaFX Toolkit not initialized errors.
- Verified all 29 tests pass successfully.

---
*PR created automatically by Jules for task [2979292118213408973](https://jules.google.com/task/2979292118213408973) started by @tkpixel*